### PR TITLE
Add a marker move listener

### DIFF
--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/Charts.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/Charts.kt
@@ -303,6 +303,9 @@ internal fun <Model : ChartEntryModel> ChartImpl(
     val interactionSource = remember { MutableInteractionSource() }
     val interaction = interactionSource.interactions.collectAsState(initial = null)
     val scrollListener = rememberScrollListener(markerTouchPoint, interaction)
+    val lastMarkerEntryModels = remember {
+        mutableStateOf<List<Marker.EntryModel>>(emptyList())
+    }
 
     axisManager.setAxes(startAxis, topAxis, endAxis, bottomAxis)
     chartScrollState.registerScrollListener(scrollListener)
@@ -392,6 +395,8 @@ internal fun <Model : ChartEntryModel> ChartImpl(
                 markerVisibilityChangeListener = markerVisibilityChangeListener,
                 wasMarkerVisible = wasMarkerVisible,
                 setWasMarkerVisible = setWasMarkerVisible,
+                lastMarkerEntryModels = lastMarkerEntryModels.value,
+                onMarkerEntryModelsChange = lastMarkerEntryModels.component2()
             )
         }
 

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/draw/ChartDrawContextExtensions.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/draw/ChartDrawContextExtensions.kt
@@ -107,6 +107,8 @@ public fun <Model : ChartEntryModel> ChartDrawContext.drawMarker(
     markerVisibilityChangeListener: MarkerVisibilityChangeListener?,
     wasMarkerVisible: Boolean,
     setWasMarkerVisible: (Boolean) -> Unit,
+    lastMarkerEntryModels: List<Marker.EntryModel>,
+    onMarkerEntryModelsChange: (List<Marker.EntryModel>) -> Unit,
 ) {
     markerTouchPoint
         ?.let(chart.entryLocationMap::getClosestMarkerEntryModel)
@@ -122,6 +124,13 @@ public fun <Model : ChartEntryModel> ChartDrawContext.drawMarker(
                     markerEntryModels = markerEntryModels,
                 )
                 setWasMarkerVisible(true)
+            }
+            if (lastMarkerEntryModels.containsAll(markerEntryModels).not()) {
+                onMarkerEntryModelsChange(markerEntryModels)
+                markerVisibilityChangeListener?.onMarkerMove(
+                    marker = marker,
+                    markerEntryModels = markerEntryModels,
+                )
             }
         } ?: marker
         .takeIf { wasMarkerVisible }

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
@@ -45,7 +45,7 @@ public interface Marker : ChartInsetter {
      * @param entry the [ChartEntry].
      * @param color the color associated with the [ChartEntry].
      */
-    public class EntryModel(
+    public data class EntryModel(
         public val location: Point,
         public val entry: ChartEntry,
         public val color: Int,

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/MarkerVisibilityChangeListener.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/MarkerVisibilityChangeListener.kt
@@ -36,6 +36,11 @@ public interface MarkerVisibilityChangeListener {
         onMarkerVisibilityChanged(isVisible = true, marker = marker)
     }
 
+    public fun onMarkerMove(
+        marker: Marker,
+        markerEntryModels: List<Marker.EntryModel>,
+    ): Unit = Unit
+
     /**
      * Called when the linked [Marker] is hidden.
      *

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/chart/BaseChartView.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/chart/BaseChartView.kt
@@ -137,6 +137,8 @@ public abstract class BaseChartView<Model : ChartEntryModel> internal constructo
 
     private var scrollDirectionResolved = false
 
+    private var lastMarkerEntryModels: List<Marker.EntryModel> = emptyList()
+
     internal val themeHandler: ThemeHandler = ThemeHandler(context, attrs, chartType)
 
     /**
@@ -391,6 +393,10 @@ public abstract class BaseChartView<Model : ChartEntryModel> internal constructo
                 markerVisibilityChangeListener = markerVisibilityChangeListener,
                 wasMarkerVisible = wasMarkerVisible,
                 setWasMarkerVisible = { wasMarkerVisible = it },
+                lastMarkerEntryModels = lastMarkerEntryModels,
+                onMarkerEntryModelsChange = {
+                    lastMarkerEntryModels = it
+                },
             )
         }
         measureContext.clearExtras()


### PR DESCRIPTION
The aim is to be able to listen for marker moves.
The new callback is added in existing MarkerVisibilityChangeListener.