### PR TITLE
Fix text sizes

### DIFF
--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/extension/ContextExtensions.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/extension/ContextExtensions.kt
@@ -17,14 +17,10 @@
 package com.patrykandpatrick.vico.core.extension
 
 import android.content.Context
-import android.os.Build
 import android.util.TypedValue
 
 /**
  * Converts the provided dimension from sp to px.
  */
-public fun Context.spToPx(sp: Float): Float = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-    TypedValue.convertDimensionToPixels(TypedValue.COMPLEX_UNIT_SP, sp, resources.displayMetrics)
-} else {
+public fun Context.spToPx(sp: Float): Float =
     TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp, resources.displayMetrics)
-}

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/extension/ContextExtensions.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/extension/ContextExtensions.kt
@@ -26,5 +26,5 @@ import android.util.TypedValue
 public fun Context.spToPx(sp: Float): Float = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
     TypedValue.convertDimensionToPixels(TypedValue.COMPLEX_UNIT_SP, sp, resources.displayMetrics)
 } else {
-    sp * resources.configuration.fontScale * resources.displayMetrics.density
+    TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp, resources.displayMetrics)
 }


### PR DESCRIPTION
Text sizes seem to small in version 1.10.0 (see screenshots in #364)

With this fix, text sizes seem to be as big as in version 1.9.2 again.
This was tested on Android 13.

Implementation note:
`convertDimensionToPixels()` is just an alias of `applyDimension()` according to the [official documentation](https://developer.android.com/reference/android/util/TypedValue#convertDimensionToPixels(int,%20float,%20android.util.DisplayMetrics))