### PR TITLE
Disable animations in previews

### DIFF
--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/Charts.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/Charts.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.chart.column.columnChart
 import com.patrykandpatrick.vico.compose.chart.entry.collectAsState
@@ -119,7 +120,7 @@ public fun <Model : ChartEntryModel> Chart(
     chartScrollSpec: ChartScrollSpec<Model> = rememberChartScrollSpec(),
     isZoomEnabled: Boolean = true,
     diffAnimationSpec: AnimationSpec<Float>? = defaultDiffAnimationSpec,
-    runInitialAnimation: Boolean = true,
+    runInitialAnimation: Boolean = !LocalInspectionMode.current,
     fadingEdges: FadingEdges? = null,
     autoScaleUp: AutoScaleUp = AutoScaleUp.Full,
     chartScrollState: ChartScrollState = rememberChartScrollState(),


### PR DESCRIPTION
This PR aims to resolve [#369](https://github.com/patrykandpatrick/vico/issues/369) by disabling animations in previws using `LocalInspectionMode.current`. One thing to note here is that as mentioned in #369 it will also disable animations in interactive previews. I was looking for a solution to detect whether preview is interactive or not, but with no luck. My rationale behind this change is that non interactive preview is shown by default and currently preview seems to be broken when using `ChartEntryModelProducer`. This PR introduces a trade-off ensuring that preview is working in non-interactive mode, but breaking interactive preview by default, since there will be no animation. I think you have to decide which behaviour is more preferable for you. If you decide to merge it, I think it would be worth to add information about interactive previews somewhere in the docs/README/kdoc, if you point me to the right spot I can do it as well. 