### PR TITLE
Marker label position

### DIFF
--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
@@ -65,11 +65,11 @@ internal fun rememberMarker(labelPosition: MarkerComponent.LabelPosition = Marke
         overlayingComponent(
             outer = indicatorOuterComponent,
             inner =
-            overlayingComponent(
-                outer = indicatorCenterComponent,
-                inner = indicatorInnerComponent,
-                innerPaddingAll = indicatorInnerAndCenterComponentPaddingValue,
-            ),
+                overlayingComponent(
+                    outer = indicatorCenterComponent,
+                    inner = indicatorInnerComponent,
+                    innerPaddingAll = indicatorInnerAndCenterComponentPaddingValue,
+                ),
             innerPaddingAll = indicatorCenterAndOuterComponentPaddingValue,
         )
     val guideline =

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
@@ -79,12 +79,7 @@ internal fun rememberMarker(labelPosition: MarkerComponent.LabelPosition = Marke
             guidelineShape,
         )
     return remember(label, labelPosition, indicator, guideline) {
-        object : MarkerComponent(
-            label = label,
-            labelPosition = labelPosition,
-            indicator = indicator,
-            guideline = guideline,
-        ) {
+        object : MarkerComponent(label, labelPosition, indicator, guideline) {
             init {
                 indicatorSizeDp = INDICATOR_SIZE_DP
                 onApplyEntryColor = { entryColor ->

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
@@ -41,7 +41,7 @@ import com.patrykandpatrick.vico.core.extension.copyColor
 import com.patrykandpatrick.vico.core.marker.Marker
 
 @Composable
-internal fun rememberMarker(labelPosition: Marker.LabelPosition = Marker.LabelPosition.Top): Marker {
+internal fun rememberMarker(labelPosition: MarkerComponent.LabelPosition = MarkerComponent.LabelPosition.Top): Marker {
     val labelBackgroundColor = MaterialTheme.colorScheme.surface
     val labelBackground =
         remember(labelBackgroundColor) {
@@ -65,11 +65,11 @@ internal fun rememberMarker(labelPosition: Marker.LabelPosition = Marker.LabelPo
         overlayingComponent(
             outer = indicatorOuterComponent,
             inner =
-                overlayingComponent(
-                    outer = indicatorCenterComponent,
-                    inner = indicatorInnerComponent,
-                    innerPaddingAll = indicatorInnerAndCenterComponentPaddingValue,
-                ),
+            overlayingComponent(
+                outer = indicatorCenterComponent,
+                inner = indicatorInnerComponent,
+                innerPaddingAll = indicatorInnerAndCenterComponentPaddingValue,
+            ),
             innerPaddingAll = indicatorCenterAndOuterComponentPaddingValue,
         )
     val guideline =
@@ -78,8 +78,13 @@ internal fun rememberMarker(labelPosition: Marker.LabelPosition = Marker.LabelPo
             guidelineThickness,
             guidelineShape,
         )
-    return remember(label, indicator, guideline) {
-        object : MarkerComponent(label, indicator, guideline, labelPosition) {
+    return remember(label, labelPosition, indicator, guideline) {
+        object : MarkerComponent(
+            label = label,
+            labelPosition = labelPosition,
+            indicator = indicator,
+            guideline = guideline,
+        ) {
             init {
                 indicatorSizeDp = INDICATOR_SIZE_DP
                 onApplyEntryColor = { entryColor ->

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
@@ -41,7 +41,7 @@ import com.patrykandpatrick.vico.core.extension.copyColor
 import com.patrykandpatrick.vico.core.marker.Marker
 
 @Composable
-internal fun rememberMarker(): Marker {
+internal fun rememberMarker(labelPosition: Marker.LabelPosition = Marker.LabelPosition.Top): Marker {
     val labelBackgroundColor = MaterialTheme.colorScheme.surface
     val labelBackground =
         remember(labelBackgroundColor) {
@@ -79,7 +79,7 @@ internal fun rememberMarker(): Marker {
             guidelineShape,
         )
     return remember(label, indicator, guideline) {
-        object : MarkerComponent(label, indicator, guideline) {
+        object : MarkerComponent(label, indicator, guideline, labelPosition) {
             init {
                 indicatorSizeDp = INDICATOR_SIZE_DP
                 onApplyEntryColor = { entryColor ->

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
@@ -18,6 +18,7 @@ package com.patrykandpatrick.vico.sample.showcase.charts
 
 import android.graphics.Typeface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -61,6 +62,10 @@ internal fun Chart3(
 
 @Composable
 private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
+    val labelPosition = remember {
+        MarkerComponent.LabelPosition.aboveIndicator()
+    }
+
     ProvideChartStyle(rememberChartStyle(chartColors)) {
         CartesianChartHost(
             chart =
@@ -95,7 +100,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
                     fadingEdges = rememberFadingEdges(),
                 ),
             modelProducer = modelProducer,
-            marker = rememberMarker(labelPosition = MarkerComponent.LabelPosition.aboveIndicator()),
+            marker = rememberMarker(labelPosition = labelPosition),
             runInitialAnimation = false,
             horizontalLayout = horizontalLayout,
         )
@@ -104,7 +109,11 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
 
 @Composable
 private fun ViewChart3(modelProducer: CartesianChartModelProducer) {
-    val marker = rememberMarker(labelPosition = MarkerComponent.LabelPosition.AboveIndicator())
+    val labelPosition = remember {
+        MarkerComponent.LabelPosition.aboveIndicator()
+    }
+    val marker = rememberMarker(labelPosition = labelPosition)
+
     AndroidViewBinding(Chart3Binding::inflate) {
         with(chartView) {
             (chart?.layers?.get(0) as LineCartesianLayer?)?.axisValueOverrider = axisValueOverrider

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
@@ -39,6 +39,7 @@ import com.patrykandpatrick.vico.core.chart.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.core.chart.layout.HorizontalLayout
 import com.patrykandpatrick.vico.core.chart.values.AxisValueOverrider
 import com.patrykandpatrick.vico.core.component.shape.Shapes
+import com.patrykandpatrick.vico.core.marker.Marker
 import com.patrykandpatrick.vico.core.model.CartesianChartModelProducer
 import com.patrykandpatrick.vico.core.model.LineCartesianLayerModel
 import com.patrykandpatrick.vico.databinding.Chart3Binding
@@ -93,7 +94,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
                     fadingEdges = rememberFadingEdges(),
                 ),
             modelProducer = modelProducer,
-            marker = rememberMarker(),
+            marker = rememberMarker(labelPosition = Marker.LabelPosition.AboveIndicator()),
             runInitialAnimation = false,
             horizontalLayout = horizontalLayout,
         )
@@ -102,7 +103,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
 
 @Composable
 private fun ViewChart3(modelProducer: CartesianChartModelProducer) {
-    val marker = rememberMarker()
+    val marker = rememberMarker(labelPosition = Marker.LabelPosition.AboveIndicator())
     AndroidViewBinding(Chart3Binding::inflate) {
         with(chartView) {
             (chart?.layers?.get(0) as LineCartesianLayer?)?.axisValueOverrider = axisValueOverrider

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
@@ -31,6 +31,7 @@ import com.patrykandpatrick.vico.compose.chart.edges.rememberFadingEdges
 import com.patrykandpatrick.vico.compose.chart.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.chart.layout.fullWidth
 import com.patrykandpatrick.vico.compose.chart.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.component.marker.aboveIndicator
 import com.patrykandpatrick.vico.compose.component.rememberShapeComponent
 import com.patrykandpatrick.vico.compose.component.rememberTextComponent
 import com.patrykandpatrick.vico.compose.dimensions.dimensionsOf
@@ -47,7 +48,6 @@ import com.patrykandpatrick.vico.databinding.Chart3Binding
 import com.patrykandpatrick.vico.sample.showcase.UISystem
 import com.patrykandpatrick.vico.sample.showcase.rememberChartStyle
 import com.patrykandpatrick.vico.sample.showcase.rememberMarker
-import com.patrykandpatrick.vico.compose.component.marker.aboveIndicator
 
 @Composable
 internal fun Chart3(
@@ -62,9 +62,10 @@ internal fun Chart3(
 
 @Composable
 private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
-    val labelPosition = remember {
-        MarkerComponent.LabelPosition.aboveIndicator()
-    }
+    val labelPosition =
+        remember {
+            MarkerComponent.LabelPosition.aboveIndicator()
+        }
 
     ProvideChartStyle(rememberChartStyle(chartColors)) {
         CartesianChartHost(
@@ -109,9 +110,10 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
 
 @Composable
 private fun ViewChart3(modelProducer: CartesianChartModelProducer) {
-    val labelPosition = remember {
-        MarkerComponent.LabelPosition.aboveIndicator()
-    }
+    val labelPosition =
+        remember {
+            MarkerComponent.LabelPosition.aboveIndicator()
+        }
     val marker = rememberMarker(labelPosition = labelPosition)
 
     AndroidViewBinding(Chart3Binding::inflate) {

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
@@ -40,13 +40,13 @@ import com.patrykandpatrick.vico.core.chart.layout.HorizontalLayout
 import com.patrykandpatrick.vico.core.chart.values.AxisValueOverrider
 import com.patrykandpatrick.vico.core.component.marker.MarkerComponent
 import com.patrykandpatrick.vico.core.component.shape.Shapes
-import com.patrykandpatrick.vico.core.marker.Marker
 import com.patrykandpatrick.vico.core.model.CartesianChartModelProducer
 import com.patrykandpatrick.vico.core.model.LineCartesianLayerModel
 import com.patrykandpatrick.vico.databinding.Chart3Binding
 import com.patrykandpatrick.vico.sample.showcase.UISystem
 import com.patrykandpatrick.vico.sample.showcase.rememberChartStyle
 import com.patrykandpatrick.vico.sample.showcase.rememberMarker
+import com.patrykandpatrick.vico.compose.component.marker.aboveIndicator
 
 @Composable
 internal fun Chart3(
@@ -95,7 +95,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
                     fadingEdges = rememberFadingEdges(),
                 ),
             modelProducer = modelProducer,
-            marker = rememberMarker(labelPosition = MarkerComponent.LabelPosition.AboveIndicator()),
+            marker = rememberMarker(labelPosition = MarkerComponent.LabelPosition.aboveIndicator()),
             runInitialAnimation = false,
             horizontalLayout = horizontalLayout,
         )

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
@@ -62,11 +62,6 @@ internal fun Chart3(
 
 @Composable
 private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
-    val labelPosition =
-        remember {
-            MarkerComponent.LabelPosition.aboveIndicator()
-        }
-
     ProvideChartStyle(rememberChartStyle(chartColors)) {
         CartesianChartHost(
             chart =
@@ -101,7 +96,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
                     fadingEdges = rememberFadingEdges(),
                 ),
             modelProducer = modelProducer,
-            marker = rememberMarker(labelPosition = labelPosition),
+            marker = rememberMarker(remember { MarkerComponent.LabelPosition.aboveIndicator() }),
             runInitialAnimation = false,
             horizontalLayout = horizontalLayout,
         )
@@ -110,11 +105,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
 
 @Composable
 private fun ViewChart3(modelProducer: CartesianChartModelProducer) {
-    val labelPosition =
-        remember {
-            MarkerComponent.LabelPosition.aboveIndicator()
-        }
-    val marker = rememberMarker(labelPosition = labelPosition)
+    val marker = rememberMarker(remember { MarkerComponent.LabelPosition.aboveIndicator() })
 
     AndroidViewBinding(Chart3Binding::inflate) {
         with(chartView) {

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
@@ -38,6 +38,7 @@ import com.patrykandpatrick.vico.core.axis.vertical.VerticalAxis
 import com.patrykandpatrick.vico.core.chart.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.core.chart.layout.HorizontalLayout
 import com.patrykandpatrick.vico.core.chart.values.AxisValueOverrider
+import com.patrykandpatrick.vico.core.component.marker.MarkerComponent
 import com.patrykandpatrick.vico.core.component.shape.Shapes
 import com.patrykandpatrick.vico.core.marker.Marker
 import com.patrykandpatrick.vico.core.model.CartesianChartModelProducer
@@ -94,7 +95,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
                     fadingEdges = rememberFadingEdges(),
                 ),
             modelProducer = modelProducer,
-            marker = rememberMarker(labelPosition = Marker.LabelPosition.AboveIndicator()),
+            marker = rememberMarker(labelPosition = MarkerComponent.LabelPosition.AboveIndicator()),
             runInitialAnimation = false,
             horizontalLayout = horizontalLayout,
         )
@@ -103,7 +104,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer) {
 
 @Composable
 private fun ViewChart3(modelProducer: CartesianChartModelProducer) {
-    val marker = rememberMarker(labelPosition = Marker.LabelPosition.AboveIndicator())
+    val marker = rememberMarker(labelPosition = MarkerComponent.LabelPosition.AboveIndicator())
     AndroidViewBinding(Chart3Binding::inflate) {
         with(chartView) {
             (chart?.layers?.get(0) as LineCartesianLayer?)?.axisValueOverrider = axisValueOverrider

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/LabelPosition.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/LabelPosition.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.component.marker
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.patrykandpatrick.vico.core.component.marker.MarkerComponent.LabelPosition
+
+/**
+ * Returns the instance of the [LabelPosition.Top] object
+ */
+public fun LabelPosition.Companion.top(): LabelPosition.Top = LabelPosition.Top
+
+/**
+ * Indicates the label should be rendered above the marker indicator
+ *
+ * @param spacing space in [Dp] between the indicator and the label
+ * @return an instance of the [LabelPosition.AboveIndicator]
+ */
+public fun LabelPosition.Companion.aboveIndicator(spacing: Dp = 2.dp): LabelPosition.AboveIndicator =
+    LabelPosition.AboveIndicator(spacing.value)

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/MarkerComponent.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/MarkerComponent.kt
@@ -27,13 +27,14 @@ import com.patrykandpatrick.vico.core.marker.Marker
  * Creates a [MarkerComponent].
  *
  * @param label the [TextComponent] to use for the label.
+ * @param labelPosition the [MarkerComponent.LabelPosition] to set the label position inside the chart
  * @param indicator the [Component] to use for the indicator.
  * @param guideline the [LineComponent] to use for the guideline.
  */
 @Composable
 public fun markerComponent(
     label: TextComponent,
-    labelPosition: Marker.LabelPosition,
+    labelPosition: MarkerComponent.LabelPosition,
     indicator: Component,
     guideline: LineComponent,
 ): MarkerComponent =

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/MarkerComponent.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/MarkerComponent.kt
@@ -21,7 +21,6 @@ import com.patrykandpatrick.vico.core.component.Component
 import com.patrykandpatrick.vico.core.component.marker.MarkerComponent
 import com.patrykandpatrick.vico.core.component.shape.LineComponent
 import com.patrykandpatrick.vico.core.component.text.TextComponent
-import com.patrykandpatrick.vico.core.marker.Marker
 
 /**
  * Creates a [MarkerComponent].

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/MarkerComponent.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/MarkerComponent.kt
@@ -21,6 +21,7 @@ import com.patrykandpatrick.vico.core.component.Component
 import com.patrykandpatrick.vico.core.component.marker.MarkerComponent
 import com.patrykandpatrick.vico.core.component.shape.LineComponent
 import com.patrykandpatrick.vico.core.component.text.TextComponent
+import com.patrykandpatrick.vico.core.marker.Marker
 
 /**
  * Creates a [MarkerComponent].
@@ -32,11 +33,13 @@ import com.patrykandpatrick.vico.core.component.text.TextComponent
 @Composable
 public fun markerComponent(
     label: TextComponent,
+    labelPosition: Marker.LabelPosition,
     indicator: Component,
     guideline: LineComponent,
 ): MarkerComponent =
     MarkerComponent(
         label = label,
+        labelPosition = labelPosition,
         indicator = indicator,
         guideline = guideline,
     )

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/MarkerComponent.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/component/marker/MarkerComponent.kt
@@ -34,7 +34,7 @@ import com.patrykandpatrick.vico.core.marker.Marker
 @Composable
 public fun markerComponent(
     label: TextComponent,
-    labelPosition: MarkerComponent.LabelPosition,
+    labelPosition: MarkerComponent.LabelPosition = MarkerComponent.LabelPosition.top(),
     indicator: Component,
     guideline: LineComponent,
 ): MarkerComponent =

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
@@ -41,15 +41,15 @@ import com.patrykandpatrick.vico.core.marker.MarkerLabelFormatter
  * The default implementation of the [Marker] interface.
  *
  * @param label the [TextComponent] used to draw the label.
- * @param labelPosition the [Marker.LabelPosition] to set the position of the marker label
+ * @param labelPosition the [LabelPosition] to set the position of the marker label
  * @param indicator an optional indicator drawn at a given point belonging to the data entry.
  * @param guideline an optional line drawn from the bottom of the chart to the bottom edge of the [label].
  */
 public open class MarkerComponent(
     public val label: TextComponent,
+    private val labelPosition: LabelPosition = LabelPosition.Top,
     public val indicator: Component?,
     public val guideline: LineComponent?,
-    private val labelPosition: Marker.LabelPosition = Marker.LabelPosition.Top,
 ) : Marker {
     private val tempBounds = RectF()
 
@@ -71,6 +71,28 @@ public open class MarkerComponent(
      * The [MarkerLabelFormatter] for this marker.
      */
     public var labelFormatter: MarkerLabelFormatter = DefaultMarkerLabelFormatter()
+
+    /**
+     * This sealed class represents the position where the label should be rendered
+     */
+    public sealed interface LabelPosition {
+        /**
+         * This is the default position.
+         *
+         * The label will be rendered on the top of the chart
+         */
+        public data object Top : LabelPosition
+
+        /**
+         * The label will be rendered on the top of the indicator.
+         *
+         * For the case of the chart holds dynamic values, the label will update its position  one the indicator updates too.
+         *
+         * @param spacingDp it's an additional space between the indicator and the label. That makes the appearance
+         * a bit more customizable for the case of custom indicators or custom label layouts.
+         */
+        public data class AboveIndicator(val spacingDp: Float = 2f) : LabelPosition
+    }
 
     override fun draw(
         context: DrawContext,
@@ -131,9 +153,9 @@ public open class MarkerComponent(
         referenceMarkerModel: Marker.EntryModel,
     ): Float {
         return when (labelPosition) {
-            Marker.LabelPosition.Top -> getLabelYTop(bounds, labelBounds)
+            LabelPosition.Top -> getLabelYTop(bounds, labelBounds)
 
-            is Marker.LabelPosition.AboveIndicator ->
+            is LabelPosition.AboveIndicator ->
                 getLabelYAboveIndicator(
                     referenceMarkerModel,
                     labelBounds,

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
@@ -41,6 +41,7 @@ import com.patrykandpatrick.vico.core.marker.MarkerLabelFormatter
  * The default implementation of the [Marker] interface.
  *
  * @param label the [TextComponent] used to draw the label.
+ * @param labelPosition the [Marker.LabelPosition] to set the position of the marker label
  * @param indicator an optional indicator drawn at a given point belonging to the data entry.
  * @param guideline an optional line drawn from the bottom of the chart to the bottom edge of the [label].
  */
@@ -48,6 +49,7 @@ public open class MarkerComponent(
     public val label: TextComponent,
     public val indicator: Component?,
     public val guideline: LineComponent?,
+    private val labelPosition: Marker.LabelPosition = Marker.LabelPosition.Top,
 ) : Marker {
     private val tempBounds = RectF()
 
@@ -75,7 +77,6 @@ public open class MarkerComponent(
         bounds: RectF,
         markedEntries: List<Marker.EntryModel>,
         chartValues: ChartValues,
-        labelPosition: Marker.LabelPosition,
     ): Unit =
         with(context) {
             drawGuideline(context, bounds, markedEntries)
@@ -91,7 +92,7 @@ public open class MarkerComponent(
                     model.location.y + halfIndicatorSize,
                 )
             }
-            drawLabel(context, bounds, markedEntries, chartValues, labelPosition)
+            drawLabel(context, bounds, markedEntries, chartValues)
         }
 
     private fun drawLabel(
@@ -99,7 +100,6 @@ public open class MarkerComponent(
         bounds: RectF,
         markedEntries: List<Marker.EntryModel>,
         chartValues: ChartValues,
-        labelPosition: Marker.LabelPosition,
     ): Unit = with(context) {
         val text = labelFormatter.getLabel(markedEntries, chartValues)
         val entryX = markedEntries.averageOf { it.location.x }
@@ -118,14 +118,13 @@ public open class MarkerComponent(
             context = context,
             text = text,
             textX = x,
-            textY = getLabelY(labelPosition, bounds, labelBounds, markedEntries.last()),
+            textY = getLabelY(bounds, labelBounds, markedEntries.last()),
             verticalPosition = VerticalPosition.Bottom,
             maxTextWidth = minOf(bounds.right - x, x - bounds.left).doubled.ceil.toInt(),
         )
     }
 
     private fun DrawContext.getLabelY(
-        labelPosition: Marker.LabelPosition,
         bounds: RectF,
         labelBounds: RectF,
         referenceMarkerModel: Marker.EntryModel,

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
@@ -124,7 +124,6 @@ public open class MarkerComponent(
                     indicatorSize -
                     spacingDp
             }
-
         }
 
         public companion object
@@ -177,13 +176,14 @@ public open class MarkerComponent(
                 context = context,
                 text = text,
                 textX = x,
-                textY = labelPosition.getY(
-                    labelTickSizeInPixels = label.tickSizeDp.pixels,
-                    chartBounds = bounds,
-                    labelBounds = labelBounds,
-                    markerModel = markedEntries.last(),
-                    indicatorSize = indicatorSizeDp,
-                ),
+                textY =
+                    labelPosition.getY(
+                        labelTickSizeInPixels = label.tickSizeDp.pixels,
+                        chartBounds = bounds,
+                        labelBounds = labelBounds,
+                        markerModel = markedEntries.last(),
+                        indicatorSize = indicatorSizeDp,
+                    ),
                 verticalPosition = VerticalPosition.Bottom,
                 maxTextWidth = minOf(bounds.right - x, x - bounds.left).doubled.ceil.toInt(),
             )

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
@@ -54,7 +54,7 @@ public open class MarkerComponent(
 ) : Marker {
     private val tempBounds = RectF()
 
-    public val TextComponent.tickSizeDp: Float
+    private val TextComponent.tickSizeDp: Float
         get() = ((background as? ShapeComponent)?.shape as? MarkerCorneredShape)?.tickSizeDp.orZero
 
     /**
@@ -97,9 +97,7 @@ public open class MarkerComponent(
                 labelBounds: RectF,
                 markerModel: Marker.EntryModel,
                 indicatorSize: Float,
-            ): Float {
-                return chartBounds.top - labelBounds.height() - labelTickSizeInPixels
-            }
+            ): Float = chartBounds.top - labelBounds.height() - labelTickSizeInPixels
         }
 
         /**
@@ -117,13 +115,7 @@ public open class MarkerComponent(
                 labelBounds: RectF,
                 markerModel: Marker.EntryModel,
                 indicatorSize: Float,
-            ): Float {
-                return markerModel.location.y -
-                    labelBounds.height() -
-                    labelTickSizeInPixels -
-                    indicatorSize -
-                    spacingDp
-            }
+            ): Float = markerModel.location.y - labelBounds.height() - labelTickSizeInPixels - indicatorSize - spacingDp
         }
 
         public companion object

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/component/marker/MarkerComponent.kt
@@ -92,6 +92,8 @@ public open class MarkerComponent(
          * a bit more customizable for the case of custom indicators or custom label layouts.
          */
         public data class AboveIndicator(val spacingDp: Float = 2f) : LabelPosition
+
+        public companion object
     }
 
     override fun draw(

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
@@ -35,14 +35,12 @@ public interface Marker : ChartInsetter {
      * @param bounds the bounds in which the marker is drawn.
      * @param markedEntries a list of [EntryModel]s representing the entries to which the marker refers.
      * @param chartValues the [CartesianChart]’s [ChartValues].
-     * @param labelPosition the position of the marker label
      */
     public fun draw(
         context: DrawContext,
         bounds: RectF,
         markedEntries: List<EntryModel>,
         chartValues: ChartValues,
-        labelPosition: LabelPosition = LabelPosition.Top
     )
 
     /**

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
@@ -66,16 +66,17 @@ public interface Marker : ChartInsetter {
          *
          * The label will be rendered on the top of the chart
          */
-        public data object Top: LabelPosition
+        public data object Top : LabelPosition
 
         /**
          * The label will be rendered on the top of the indicator.
          *
          * For the case of the chart holds dynamic values, the label will update its position  one the indicator updates too.
          *
-         * @param spacingDp it's an additional space between the indicator and the label. That makes the appearance a bit more customizable.
+         * @param spacingDp it's an additional space between the indicator and the label. That makes the appearance
+         * a bit more customizable for the case of custom indicators or custom label layouts.
          */
-        public data class AboveIndicator(val spacingDp: Float = 0f) : LabelPosition
+        public data class AboveIndicator(val spacingDp: Float = 2f) : LabelPosition
     }
 }
 

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
@@ -56,28 +56,6 @@ public interface Marker : ChartInsetter {
         public val color: Int,
         public val index: Int,
     )
-
-    /**
-     * This sealed class represents the position where the label should be rendered
-     */
-    public sealed interface LabelPosition {
-        /**
-         * This is the default position.
-         *
-         * The label will be rendered on the top of the chart
-         */
-        public data object Top : LabelPosition
-
-        /**
-         * The label will be rendered on the top of the indicator.
-         *
-         * For the case of the chart holds dynamic values, the label will update its position  one the indicator updates too.
-         *
-         * @param spacingDp it's an additional space between the indicator and the label. That makes the appearance
-         * a bit more customizable for the case of custom indicators or custom label layouts.
-         */
-        public data class AboveIndicator(val spacingDp: Float = 2f) : LabelPosition
-    }
 }
 
 internal fun HashMap<Float, MutableList<Marker.EntryModel>>.put(

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/marker/Marker.kt
@@ -35,12 +35,14 @@ public interface Marker : ChartInsetter {
      * @param bounds the bounds in which the marker is drawn.
      * @param markedEntries a list of [EntryModel]s representing the entries to which the marker refers.
      * @param chartValues the [CartesianChart]’s [ChartValues].
+     * @param labelPosition the position of the marker label
      */
     public fun draw(
         context: DrawContext,
         bounds: RectF,
         markedEntries: List<EntryModel>,
         chartValues: ChartValues,
+        labelPosition: LabelPosition = LabelPosition.Top
     )
 
     /**
@@ -56,6 +58,27 @@ public interface Marker : ChartInsetter {
         public val color: Int,
         public val index: Int,
     )
+
+    /**
+     * This sealed class represents the position where the label should be rendered
+     */
+    public sealed interface LabelPosition {
+        /**
+         * This is the default position.
+         *
+         * The label will be rendered on the top of the chart
+         */
+        public data object Top: LabelPosition
+
+        /**
+         * The label will be rendered on the top of the indicator.
+         *
+         * For the case of the chart holds dynamic values, the label will update its position  one the indicator updates too.
+         *
+         * @param spacingDp it's an additional space between the indicator and the label. That makes the appearance a bit more customizable.
+         */
+        public data class AboveIndicator(val spacingDp: Float = 0f) : LabelPosition
+    }
 }
 
 internal fun HashMap<Float, MutableList<Marker.EntryModel>>.put(


### PR DESCRIPTION
# Description
This pull request allows the users to choose where the marker label should be rendered inside the Chart. 
## Why?
Sometimes it's a requirement from the design team to position the label of the marked in a specific place inside the chart. Mine was to show the labels close to the marker indicator.

## How?
First, I created a sealed interface with two implementations to represent where we want to render the label. The `Top` implementation represents the previous behaviour of showing the labels always on top. The `AboveIndicator`, as the name suggests, represents the behaviour of rendering the label above the marker's indicator. I've added a `spacingDp` argument to add a bit more space between the indicator and the label. That would be useful when the user has a custom label layout or/and custom indicators and wants to fine-adjust the spacing between them. 

Then, I updated the `MarkerComponent` to receive the label position. I extracted the current implementation of the Y position of the label and put it alongside the new position calculation separated by a `when` structure. This way, if someone decides to implement another position, they only need to implement a new branch.

And finally, I updated the sample application by using the new label position on the `Chart3`

## What does that look like?

https://github.com/patrykandpatrick/vico/assets/10220064/05765188-ea90-4a78-8190-d2792b928f00

