### PR TITLE
Expose TextComponent functions which accept androidx.compose.ui.text.TextStyle

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="20" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/AxisLinePreviews.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/AxisLinePreviews.kt
@@ -18,6 +18,7 @@ package com.patrykandpatrick.vico.sample.previews
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
@@ -46,6 +47,7 @@ private val model = CartesianChartModel(ColumnCartesianLayerModel.build { series
 fun HorizontalAxisTextInside() {
     val label =
         rememberAxisLabelComponent(
+            style = TextStyle.Default,
             background =
                 rememberShapeComponent(
                     shape =
@@ -101,6 +103,7 @@ fun HorizontalAxisTextInside() {
 fun HorizontalAxisTextInsideAndBottomAxis() {
     val label =
         rememberAxisLabelComponent(
+            style = TextStyle.Default,
             background =
                 rememberShapeComponent(
                     shape = Shape.Pill,

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/ColumnChartsWithNegativeValuesPreviews.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/ColumnChartsWithNegativeValuesPreviews.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
@@ -66,7 +67,9 @@ public fun SingleColumnChartWithNegativeValuesAndDataLabels() {
         CartesianChartHost(
             chart =
                 rememberCartesianChart(
-                    rememberColumnCartesianLayer(dataLabel = rememberTextComponent()),
+                    rememberColumnCartesianLayer(
+                        dataLabel = rememberTextComponent(style = TextStyle.Default)
+                    ),
                     startAxis = rememberStartAxis(),
                     bottomAxis = rememberBottomAxis(),
                 ),

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/ContainedChartsPreview.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/ContainedChartsPreview.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
@@ -90,14 +91,14 @@ private fun getLineLayer(verticalAxisPosition: Vertical? = null) =
 private val startAxis: Axis<Start>
     @Composable get() =
         rememberStartAxis(
-            label = rememberTextComponent(color = Color.Black),
+            label = rememberTextComponent(style = TextStyle.Default, color = Color.Black),
             itemPlacer = remember { AxisItemPlacer.Vertical.count(count = { 5 }) },
         )
 
 private val endAxis: Axis<End>
     @Composable get() =
         rememberEndAxis(
-            label = rememberTextComponent(color = Color.DarkGray),
+            label = rememberTextComponent(style = TextStyle.Default, color = Color.DarkGray),
             itemPlacer = remember { AxisItemPlacer.Vertical.count(count = { 7 }) },
         )
 

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/HorizontalDecorationPreviews.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/HorizontalDecorationPreviews.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
@@ -119,6 +120,7 @@ fun ThresholdLineWithCustomText() {
                                 line = rememberLineComponent(color = Color.Black, thickness = 2.dp),
                                 labelComponent =
                                     rememberTextComponent(
+                                        style = TextStyle.Default,
                                         color = Color.White,
                                         lineCount = 3,
                                         background =
@@ -147,6 +149,7 @@ fun ThresholdLineWithCustomText() {
                                 line = rememberLineComponent(color = Color.DarkGray, thickness = 2.dp),
                                 labelComponent =
                                     rememberTextComponent(
+                                        style = TextStyle.Default,
                                         color = Color.White,
                                         lineCount = 3,
                                         background =
@@ -195,6 +198,7 @@ fun RangedThresholdLine() {
                                 box = rememberShapeComponent(color = Color.Black.copy(alpha = .5f)),
                                 labelComponent =
                                     rememberTextComponent(
+                                        style = TextStyle.Default,
                                         color = Color.Black,
                                         padding = MutableDimensions.of(horizontal = 8.dp),
                                     ),
@@ -236,6 +240,7 @@ fun RangedThresholdLineWithBrushShader() {
                                     ),
                                 labelComponent =
                                     rememberTextComponent(
+                                        style = TextStyle.Default,
                                         color = Color.Black,
                                         padding = MutableDimensions.of(horizontal = 8.dp),
                                     ),
@@ -276,6 +281,7 @@ fun RangedThresholdLineWithComponentShader() {
                                     ),
                                 labelComponent =
                                     rememberTextComponent(
+                                        style = TextStyle.Default,
                                         color = Color.Black,
                                         padding = MutableDimensions.of(horizontal = 8.dp),
                                     ),

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/LineChartsWithNegativeValuesPreviews.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/LineChartsWithNegativeValuesPreviews.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
@@ -96,7 +97,9 @@ fun SingleLineChartWithNegativeValuesAndDataLabels() {
                             listOf(
                                 rememberLineSpec(
                                     shader = DynamicShader.color(Color.DarkGray),
-                                    dataLabel = rememberTextComponent(),
+                                    dataLabel = rememberTextComponent(
+                                        style = TextStyle.Default,
+                                    ),
                                 ),
                             ),
                     ),

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/StackedColumnChartsWithNegativeValuesPreviews.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/StackedColumnChartsWithNegativeValuesPreviews.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
@@ -90,7 +91,7 @@ public fun StackedColumnChartWithNegativeValuesAndDataLabels() {
                 rememberCartesianChart(
                     rememberColumnCartesianLayer(
                         columnProvider = columnProvider,
-                        dataLabel = rememberTextComponent(),
+                        dataLabel = rememberTextComponent(style = TextStyle.Default),
                         mergeMode = { ColumnCartesianLayer.MergeMode.Stacked },
                     ),
                     startAxis =

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart7.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart7.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidViewBinding
@@ -147,6 +148,7 @@ private fun ViewChart7(
 @Composable
 private fun rememberStartAxisLabel() =
     rememberAxisLabelComponent(
+        style = TextStyle.Default,
         color = Color.Black,
         background =
             rememberShapeComponent(

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart9.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart9.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import com.patrykandpatrick.vico.R
@@ -153,6 +154,7 @@ private fun ComposeChart9(
                     rememberStartAxis(
                         label =
                             rememberAxisLabelComponent(
+                                style = TextStyle.Default,
                                 color = MaterialTheme.colorScheme.onBackground,
                                 background =
                                     rememberShapeComponent(

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/axis/AxisComponents.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/axis/AxisComponents.kt
@@ -31,13 +31,13 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.patrykandpatrick.vico.compose.common.VicoTheme
 import com.patrykandpatrick.vico.compose.common.component.rememberLineComponent
 import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
 import com.patrykandpatrick.vico.compose.common.of
 import com.patrykandpatrick.vico.compose.common.shader.BrushShader
 import com.patrykandpatrick.vico.compose.common.shape.dashed
 import com.patrykandpatrick.vico.compose.common.shape.toVicoShape
-import com.patrykandpatrick.vico.compose.common.VicoTheme
 import com.patrykandpatrick.vico.compose.common.vicoTheme
 import com.patrykandpatrick.vico.core.common.Defaults
 import com.patrykandpatrick.vico.core.common.Dimensions
@@ -62,7 +62,9 @@ import com.patrykandpatrick.vico.core.common.shape.Shape
  * @param textAlignment the text alignment.
  */
 @Deprecated(
-    message = "Use the Composable function that accepts a Compose UI TextStyle instead of an android graphics Typeface.",
+    message = """
+        Use the Composable function that accepts a Compose UI TextStyle instead of an android graphics Typeface.
+    """,
 )
 @Composable
 public fun rememberAxisLabelComponent(
@@ -93,8 +95,10 @@ public fun rememberAxisLabelComponent(
 /**
  * Creates and remembers a [TextComponent] to be used for axis labels.
  *
- * @param textStyle the [TextStyle] for the text. This parameter controls the text's font, the text's color, and the
- * size of the text. A [Color.Unspecified] text color will default this text's color to [VicoTheme.textColor].
+ * @param style the [TextStyle] for the text.
+ * @param color the [Color] of the text. The default value is [style.color][TextStyle.color] if [Color.isSpecified] is
+ * true, otherwise the default is [vicoTheme.textColor][VicoTheme.textColor].
+ * @param size the text's size. The default value is [style.fontSize][TextStyle.fontSize].
  * @param background an optional [ShapeComponent] to be displayed behind the text.
  * @param ellipsize the text truncation behavior.
  * @param lineCount the line count.
@@ -104,29 +108,35 @@ public fun rememberAxisLabelComponent(
  */
 @Composable
 public fun rememberAxisLabelComponent(
-    textStyle: TextStyle = TextStyle.Default,
+    style: TextStyle = TextStyle.Default,
+    color: Color = if (style.color.isSpecified) style.color else vicoTheme.textColor,
+    size: TextUnit = style.fontSize,
     background: ShapeComponent? = null,
     ellipsize: TextUtils.TruncateAt = TextUtils.TruncateAt.END,
     lineCount: Int = Defaults.AXIS_LABEL_MAX_LINES,
-    padding: MutableDimensions = MutableDimensions.of(
-        Defaults.AXIS_LABEL_HORIZONTAL_PADDING.dp,
-        Defaults.AXIS_LABEL_VERTICAL_PADDING.dp
-    ),
-    margins: MutableDimensions = MutableDimensions.of(
-        Defaults.AXIS_LABEL_HORIZONTAL_MARGIN.dp,
-        Defaults.AXIS_LABEL_VERTICAL_MARGIN.dp
-    ),
+    padding: MutableDimensions =
+        MutableDimensions.of(
+            Defaults.AXIS_LABEL_HORIZONTAL_PADDING.dp,
+            Defaults.AXIS_LABEL_VERTICAL_PADDING.dp,
+        ),
+    margins: MutableDimensions =
+        MutableDimensions.of(
+            Defaults.AXIS_LABEL_HORIZONTAL_MARGIN.dp,
+            Defaults.AXIS_LABEL_VERTICAL_MARGIN.dp,
+        ),
     textAlignment: Layout.Alignment = Layout.Alignment.ALIGN_NORMAL,
-): TextComponent = rememberTextComponent(
-    if (textStyle.color.isSpecified) textStyle else textStyle.copy(color = vicoTheme.textColor),
-    background,
-    ellipsize,
-    lineCount,
-    padding,
-    margins,
-    textAlignment,
-)
-
+): TextComponent =
+    rememberTextComponent(
+        style = style,
+        color = color,
+        size = size,
+        background = background,
+        ellipsize = ellipsize,
+        lineCount = lineCount,
+        padding = padding,
+        margins = margins,
+        textAlignment = textAlignment,
+    )
 
 /**
  * Creates and remembers a [LineComponent] styled as an axis line.

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/axis/AxisComponents.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/axis/AxisComponents.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DeprecatedCallableAddReplaceWith")
+
 package com.patrykandpatrick.vico.compose.cartesian.axis
 
 import android.graphics.Typeface
@@ -23,6 +25,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -33,6 +37,7 @@ import com.patrykandpatrick.vico.compose.common.of
 import com.patrykandpatrick.vico.compose.common.shader.BrushShader
 import com.patrykandpatrick.vico.compose.common.shape.dashed
 import com.patrykandpatrick.vico.compose.common.shape.toVicoShape
+import com.patrykandpatrick.vico.compose.common.VicoTheme
 import com.patrykandpatrick.vico.compose.common.vicoTheme
 import com.patrykandpatrick.vico.core.common.Defaults
 import com.patrykandpatrick.vico.core.common.Dimensions
@@ -56,6 +61,9 @@ import com.patrykandpatrick.vico.core.common.shape.Shape
  * @param typeface the [Typeface] for the text.
  * @param textAlignment the text alignment.
  */
+@Deprecated(
+    message = "Use the Composable function that accepts a Compose UI TextStyle instead of an android graphics Typeface.",
+)
 @Composable
 public fun rememberAxisLabelComponent(
     color: Color = vicoTheme.textColor,
@@ -81,6 +89,44 @@ public fun rememberAxisLabelComponent(
         typeface,
         textAlignment,
     )
+
+/**
+ * Creates and remembers a [TextComponent] to be used for axis labels.
+ *
+ * @param textStyle the [TextStyle] for the text. This parameter controls the text's font, the text's color, and the
+ * size of the text. A [Color.Unspecified] text color will default this text's color to [VicoTheme.textColor].
+ * @param background an optional [ShapeComponent] to be displayed behind the text.
+ * @param ellipsize the text truncation behavior.
+ * @param lineCount the line count.
+ * @param padding the padding between the text and the background.
+ * @param margins the margins around the background.
+ * @param textAlignment the text alignment.
+ */
+@Composable
+public fun rememberAxisLabelComponent(
+    textStyle: TextStyle = TextStyle.Default,
+    background: ShapeComponent? = null,
+    ellipsize: TextUtils.TruncateAt = TextUtils.TruncateAt.END,
+    lineCount: Int = Defaults.AXIS_LABEL_MAX_LINES,
+    padding: MutableDimensions = MutableDimensions.of(
+        Defaults.AXIS_LABEL_HORIZONTAL_PADDING.dp,
+        Defaults.AXIS_LABEL_VERTICAL_PADDING.dp
+    ),
+    margins: MutableDimensions = MutableDimensions.of(
+        Defaults.AXIS_LABEL_HORIZONTAL_MARGIN.dp,
+        Defaults.AXIS_LABEL_VERTICAL_MARGIN.dp
+    ),
+    textAlignment: Layout.Alignment = Layout.Alignment.ALIGN_NORMAL,
+): TextComponent = rememberTextComponent(
+    if (textStyle.color.isSpecified) textStyle else textStyle.copy(color = vicoTheme.textColor),
+    background,
+    ellipsize,
+    lineCount,
+    padding,
+    margins,
+    textAlignment,
+)
+
 
 /**
  * Creates and remembers a [LineComponent] styled as an axis line.

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/axis/HorizontalAxis.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/axis/HorizontalAxis.kt
@@ -18,6 +18,7 @@ package com.patrykandpatrick.vico.compose.cartesian.axis
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.core.cartesian.CartesianValueFormatter
@@ -46,7 +47,7 @@ import com.patrykandpatrick.vico.core.common.component.TextComponent
  */
 @Composable
 public fun rememberTopAxis(
-    label: TextComponent? = rememberAxisLabelComponent(),
+    label: TextComponent? = rememberAxisLabelComponent(style = TextStyle.Default),
     axis: LineComponent? = rememberAxisLineComponent(),
     tick: LineComponent? = rememberAxisTickComponent(),
     tickLength: Dp = Defaults.AXIS_TICK_LENGTH.dp,
@@ -89,7 +90,7 @@ public fun rememberTopAxis(
  */
 @Composable
 public fun rememberBottomAxis(
-    label: TextComponent? = rememberAxisLabelComponent(),
+    label: TextComponent? = rememberAxisLabelComponent(style = TextStyle.Default),
     axis: LineComponent? = rememberAxisLineComponent(),
     tick: LineComponent? = rememberAxisTickComponent(),
     tickLength: Dp = Defaults.AXIS_TICK_LENGTH.dp,

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/axis/VerticalAxis.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/axis/VerticalAxis.kt
@@ -18,6 +18,7 @@ package com.patrykandpatrick.vico.compose.cartesian.axis
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.core.cartesian.CartesianValueFormatter
@@ -48,7 +49,7 @@ import com.patrykandpatrick.vico.core.common.component.TextComponent
  */
 @Composable
 public fun rememberStartAxis(
-    label: TextComponent? = rememberAxisLabelComponent(),
+    label: TextComponent? = rememberAxisLabelComponent(style = TextStyle.Default),
     axis: LineComponent? = rememberAxisLineComponent(),
     tick: LineComponent? = rememberAxisTickComponent(),
     tickLength: Dp = Defaults.AXIS_TICK_LENGTH.dp,
@@ -97,7 +98,7 @@ public fun rememberStartAxis(
  */
 @Composable
 public fun rememberEndAxis(
-    label: TextComponent? = rememberAxisLabelComponent(),
+    label: TextComponent? = rememberAxisLabelComponent(style = TextStyle.Default),
     axis: LineComponent? = rememberAxisLineComponent(),
     tick: LineComponent? = rememberAxisTickComponent(),
     tickLength: Dp = Defaults.AXIS_TICK_LENGTH.dp,

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/common/component/Components.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/common/component/Components.kt
@@ -25,13 +25,16 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.patrykandpatrick.vico.compose.common.pixelSize
 import com.patrykandpatrick.vico.compose.common.shader.toDynamicShader
+import com.patrykandpatrick.vico.compose.common.text.toGraphicsTypeFace
 import com.patrykandpatrick.vico.core.common.Defaults
 import com.patrykandpatrick.vico.core.common.Dimensions
 import com.patrykandpatrick.vico.core.common.LayeredComponent
@@ -154,6 +157,9 @@ public fun rememberLayeredComponent(
  * @param textAlignment the text alignment.
  * @param minWidth defines the minimum width.
  */
+@Deprecated(
+    message = "Use the Composable function that accepts a Compose UI TextStyle instead of an android graphics Typeface.",
+)
 @Composable
 public fun rememberTextComponent(
     color: Color = Color.Black,
@@ -181,6 +187,47 @@ public fun rememberTextComponent(
             this.minWidth = minWidth
         }
     }
+
+/**
+ * Create and remember [TextComponent].
+ *
+ * @param textStyle the [TextStyle] for the text. This parameter controls the text's font, the text's color, and the
+ * size of the text. A [Color.Unspecified] text color will default this text's color to [Color.Black].
+ * @param background an optional [ShapeComponent] to be displayed behind the text.
+ * @param ellipsize the text truncation behavior.
+ * @param lineCount the line count.
+ * @param padding the padding between the text and the background.
+ * @param margins the margins around the background.
+ * @param textAlignment the text alignment.
+ * @param minWidth defines the minimum width.
+ */
+@Composable
+public fun rememberTextComponent(
+    textStyle: TextStyle = TextStyle.Default,
+    background: ShapeComponent? = null,
+    ellipsize: TextUtils.TruncateAt = TextUtils.TruncateAt.END,
+    lineCount: Int = Defaults.LABEL_LINE_COUNT,
+    padding: MutableDimensions = MutableDimensions.empty(),
+    margins: MutableDimensions = MutableDimensions.empty(),
+    textAlignment: Layout.Alignment = Layout.Alignment.ALIGN_NORMAL,
+    minWidth: TextComponent.MinWidth = TextComponent.MinWidth.fixed(),
+): TextComponent {
+    val typeface = textStyle.toGraphicsTypeFace()
+    return remember(textStyle, typeface, background, ellipsize, lineCount, padding, margins, typeface, textAlignment, minWidth) {
+        TextComponent.build {
+            this.color = if (textStyle.color.isSpecified) textStyle.color.toArgb() else Color.Black.toArgb()
+            this.textSizeSp = textStyle.fontSize.pixelSize()
+            this.ellipsize = ellipsize
+            this.lineCount = lineCount
+            this.background = background
+            this.padding = padding
+            this.margins = margins
+            this.typeface = typeface
+            this.textAlignment = textAlignment
+            this.minWidth = minWidth
+        }
+    }
+}
 
 /** A [Dp] version of [TextComponent.MinWidth.fixed]. */
 @Stable

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/common/component/Components.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/common/component/Components.kt
@@ -158,7 +158,9 @@ public fun rememberLayeredComponent(
  * @param minWidth defines the minimum width.
  */
 @Deprecated(
-    message = "Use the Composable function that accepts a Compose UI TextStyle instead of an android graphics Typeface.",
+    message = """
+        Use the Composable function that accepts a Compose UI TextStyle instead of an android graphics Typeface.
+    """,
 )
 @Composable
 public fun rememberTextComponent(
@@ -191,8 +193,10 @@ public fun rememberTextComponent(
 /**
  * Create and remember [TextComponent].
  *
- * @param textStyle the [TextStyle] for the text. This parameter controls the text's font, the text's color, and the
- * size of the text. A [Color.Unspecified] text color will default this text's color to [Color.Black].
+ * @param style the [TextStyle] for the text.
+ * @param color the [Color] of the text. The default value is [style.color][TextStyle.color] if [Color.isSpecified] is
+ * true, otherwise the default is [Color.Black].
+ * @param size the text's size. The default value is [style.fontSize][TextStyle.fontSize].
  * @param background an optional [ShapeComponent] to be displayed behind the text.
  * @param ellipsize the text truncation behavior.
  * @param lineCount the line count.
@@ -203,7 +207,9 @@ public fun rememberTextComponent(
  */
 @Composable
 public fun rememberTextComponent(
-    textStyle: TextStyle = TextStyle.Default,
+    style: TextStyle = TextStyle.Default,
+    color: Color = if (style.color.isSpecified) style.color else Color.Black,
+    size: TextUnit = style.fontSize,
     background: ShapeComponent? = null,
     ellipsize: TextUtils.TruncateAt = TextUtils.TruncateAt.END,
     lineCount: Int = Defaults.LABEL_LINE_COUNT,
@@ -212,11 +218,21 @@ public fun rememberTextComponent(
     textAlignment: Layout.Alignment = Layout.Alignment.ALIGN_NORMAL,
     minWidth: TextComponent.MinWidth = TextComponent.MinWidth.fixed(),
 ): TextComponent {
-    val typeface = textStyle.toGraphicsTypeFace()
-    return remember(textStyle, typeface, background, ellipsize, lineCount, padding, margins, typeface, textAlignment, minWidth) {
+    val typeface = style.toGraphicsTypeFace()
+    return remember(
+        style, typeface, color, size,
+        background,
+        ellipsize,
+        lineCount,
+        padding,
+        margins,
+        typeface,
+        textAlignment,
+        minWidth,
+    ) {
         TextComponent.build {
-            this.color = if (textStyle.color.isSpecified) textStyle.color.toArgb() else Color.Black.toArgb()
-            this.textSizeSp = textStyle.fontSize.pixelSize()
+            this.color = color.toArgb()
+            this.textSizeSp = size.pixelSize()
             this.ellipsize = ellipsize
             this.lineCount = lineCount
             this.background = background

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/common/text/Typeface.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/common/text/Typeface.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.common.text
+
+import android.graphics.Typeface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontSynthesis
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.resolveAsTypeface
+
+/**
+ * Coerce a Jetpack Compose UI [TextStyle] to a corresponding [Typeface].
+ */
+@Composable
+internal fun TextStyle.toGraphicsTypeFace(): Typeface {
+    val resolver = LocalFontFamilyResolver.current
+    return remember(resolver, this) {
+        resolver.resolveAsTypeface(
+            fontFamily = this.fontFamily,
+            fontWeight = this.fontWeight ?: FontWeight.Normal,
+            fontStyle = this.fontStyle ?: FontStyle.Normal,
+            fontSynthesis = this.fontSynthesis ?: FontSynthesis.All,
+        )
+    }.value
+}


### PR DESCRIPTION
The functions `rememberTextComponent` and `rememberAxisLabelComponent`
now both accept a `TextStyle` that dictates the text's color, size,
and font. Previously, these functions accepted three parameters for
these values. This was awkward for Compose callers, particularly for
the `android.graphics.Typeface` value.
