### PR TITLE
Dashed Path support for Line Layer

### DIFF
--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart9.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart9.kt
@@ -16,6 +16,7 @@
 
 package com.patrykandpatrick.vico.sample.showcase.charts
 
+import android.graphics.DashPathEffect
 import android.graphics.PorterDuff
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -100,6 +101,8 @@ private fun ComposeChart9(
 ) {
     val colors = chartColors
     val marker = rememberMarker()
+    // Set dashed line style
+    val dashPathEffect = DashPathEffect(floatArrayOf(PATH_EFFECT_DASH_LENGTH, PATH_EFFECT_DASH_GAP), 0f)
     CartesianChartHost(
         chart =
             rememberCartesianChart(
@@ -146,6 +149,7 @@ private fun ComposeChart9(
                                             PorterDuff.Mode.DST_IN,
                                         ),
                                     ),
+                                pathEffect = dashPathEffect,
                             ),
                         ),
                 ),
@@ -207,6 +211,8 @@ private fun ViewChart9(
 ) {
     val marker = rememberMarker()
     val colors = chartColors
+    // Set dashed line style
+    val dashPathEffect = DashPathEffect(floatArrayOf(PATH_EFFECT_DASH_LENGTH, PATH_EFFECT_DASH_GAP), 0f)
     AndroidViewBinding(Chart9Binding::inflate, modifier) {
         with(chartView) {
             runInitialAnimation = false
@@ -252,6 +258,7 @@ private fun ViewChart9(
                                         PorterDuff.Mode.DST_IN,
                                     ),
                                 ),
+                            pathEffect = dashPathEffect,
                         ),
                     )
             }
@@ -269,3 +276,6 @@ private val chartColors
         )
 
 private val x = (1..100).toList()
+
+private const val PATH_EFFECT_DASH_LENGTH = 20f // Length of each dash
+private const val PATH_EFFECT_DASH_GAP = 10f // Length of the gap between dashes

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/layer/LineCartesianLayer.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/layer/LineCartesianLayer.kt
@@ -17,6 +17,7 @@
 package com.patrykandpatrick.vico.compose.cartesian.layer
 
 import android.graphics.Paint
+import android.graphics.PathEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Brush
@@ -92,6 +93,7 @@ public fun rememberLineCartesianLayer(
  * @param dataLabelValueFormatter the [CartesianValueFormatter] to use for data labels.
  * @param dataLabelRotationDegrees the rotation of data labels in degrees.
  * @param pointConnector the [LineSpec.PointConnector] for the line.
+ * @param pathEffect the [PathEffect] to apply to the line.
  */
 @Composable
 public fun rememberLineSpec(
@@ -106,6 +108,7 @@ public fun rememberLineSpec(
     dataLabelValueFormatter: CartesianValueFormatter = remember { CartesianValueFormatter.decimal() },
     dataLabelRotationDegrees: Float = 0f,
     pointConnector: LineSpec.PointConnector = DefaultPointConnector(),
+    pathEffect: PathEffect? = null,
 ): LineSpec =
     remember(
         shader,
@@ -132,6 +135,7 @@ public fun rememberLineSpec(
             dataLabelValueFormatter = dataLabelValueFormatter,
             dataLabelRotationDegrees = dataLabelRotationDegrees,
             pointConnector = pointConnector,
+            pathEffect = pathEffect,
         )
     }
 

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/LineCartesianLayer.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/LineCartesianLayer.kt
@@ -18,6 +18,7 @@ package com.patrykandpatrick.vico.core.cartesian.layer
 
 import android.graphics.Paint
 import android.graphics.Path
+import android.graphics.PathEffect
 import android.graphics.RectF
 import com.patrykandpatrick.vico.core.cartesian.CartesianDrawContext
 import com.patrykandpatrick.vico.core.cartesian.CartesianMeasureContext
@@ -106,6 +107,7 @@ public open class LineCartesianLayer(
      * @param dataLabelValueFormatter the [CartesianValueFormatter] to use for data labels.
      * @param dataLabelRotationDegrees the rotation of data labels (in degrees).
      * @param pointConnector the [PointConnector] for the line.
+     * @param pathEffect the [PathEffect] to apply to the line.
      */
     public open class LineSpec(
         public var shader: DynamicShader,
@@ -119,6 +121,7 @@ public open class LineCartesianLayer(
         public var dataLabelValueFormatter: CartesianValueFormatter = CartesianValueFormatter.decimal(),
         public var dataLabelRotationDegrees: Float = 0f,
         public var pointConnector: PointConnector = DefaultPointConnector(),
+        public var pathEffect: PathEffect? = null,
     ) {
         /**
          * Returns `true` if the [backgroundShader] is not null, and `false` otherwise.
@@ -172,6 +175,9 @@ public open class LineCartesianLayer(
             with(context) {
                 linePaint.strokeWidth = thicknessDp.pixels
                 setSplitY(zeroLineYFraction)
+                pathEffect?.let {
+                    linePaint.pathEffect = it
+                }
                 linePaint.shader = shader.provideShader(context, bounds)
                 linePaint.withOpacity(opacity) { canvas.drawPath(path, it) }
             }
@@ -622,6 +628,7 @@ public fun LineSpec.copy(
     dataLabelValueFormatter: CartesianValueFormatter = this.dataLabelValueFormatter,
     dataLabelRotationDegrees: Float = this.dataLabelRotationDegrees,
     pointConnector: PointConnector = this.pointConnector,
+    pathEffect: PathEffect? = this.pathEffect,
 ): LineSpec =
     LineSpec(
         shader = shader,
@@ -635,6 +642,7 @@ public fun LineSpec.copy(
         dataLabelValueFormatter = dataLabelValueFormatter,
         dataLabelRotationDegrees = dataLabelRotationDegrees,
         pointConnector = pointConnector,
+        pathEffect = pathEffect,
     )
 
 internal fun Component.drawPoint(


### PR DESCRIPTION
# Description
This pull request enables users to add a `android.graphics.PathEffect` of their choice to the `LineCartesianLayer`.

# Why?
On occasion, the design team may require a dashed pattern for the lines on the Line Layer. There's also an ongoing discussion about adding support for a Dashed Line 
- #469 

With this update, users can add any `PathEffect` they prefer, allowing them more flexibility than just a dashed effect.

# How?
First, I added a nullable `pathEffect` property to the `LineSpec` in `/core/cartesian/layer/LineCartesianLayer.kt` class. Utilizing the library's extensive APIs, I assigned this `pathEffect` to `linePaint` within the `drawLine()` function.

Next, I updated the `rememberLineSpec()` function in `/compose/cartesian/layer/LineCartesianLayer.kt` to include the `pathEffect` property.

And finally, I updated the sample application by using the `pathEffect` property on `Chart9`. This shows how simple it is to add a new line effect.

# What does that look like?

| Default Behavior | with `DashPathEffect` |
| ---| ---|
| <img src="https://github.com/patrykandpatrick/vico/assets/9023987/36d3f0c9-613a-4e34-a190-52297e0ec031" width=250 height=550/> | <img src="https://github.com/patrykandpatrick/vico/assets/9023987/150cdf22-97eb-440b-8da8-8f95f9c803aa" width=250 height=550/> |

| Default Behavior | with `DashPathEffect` |
| ---| ---|
| <video src="https://github.com/patrykandpatrick/vico/assets/9023987/72a197f8-8c40-462c-a91f-ec347617f077"/> | <video src="https://github.com/patrykandpatrick/vico/assets/9023987/cd0eb0d8-8fef-4cba-89fc-6fb3ac4085a1"/> |