### PR TITLE
Add Bottom to LabelPosition for Cartesian Charts

### DIFF
--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
@@ -102,16 +102,16 @@ internal fun rememberMarker(
             ) {
                 with(context) {
                     super.getInsets(context, outInsets, horizontalDimensions)
-                    val shadowClipping =
+                    val shadowInset =
                         (
                             CLIPPING_FREE_SHADOW_RADIUS_MULTIPLIER * LABEL_BACKGROUND_SHADOW_RADIUS_DP -
                                 LABEL_BACKGROUND_SHADOW_DY_DP
                         )
                             .pixels
                     when (labelPosition) {
-                        LabelPosition.Top -> outInsets.top += shadowClipping
-                        LabelPosition.Bottom -> outInsets.bottom += shadowClipping
-                        LabelPosition.AroundPoint, LabelPosition.AbovePoint -> Unit
+                        LabelPosition.Top, LabelPosition.AroundPoint, LabelPosition.AbovePoint ->
+                            outInsets.top += shadowInset
+                        LabelPosition.Bottom -> outInsets.bottom += shadowInset
                     }
                 }
             }

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
@@ -101,14 +101,18 @@ internal fun rememberMarker(
                 horizontalDimensions: HorizontalDimensions,
             ) {
                 with(context) {
-                    outInsets.top =
+                    super.getInsets(context, outInsets, horizontalDimensions)
+                    val shadowClipping =
                         (
                             CLIPPING_FREE_SHADOW_RADIUS_MULTIPLIER * LABEL_BACKGROUND_SHADOW_RADIUS_DP -
                                 LABEL_BACKGROUND_SHADOW_DY_DP
                         )
                             .pixels
-                    if (labelPosition == LabelPosition.AroundPoint) return
-                    outInsets.top += label.getHeight(context) + labelBackgroundShape.tickSizeDp.pixels
+                    when (labelPosition) {
+                        LabelPosition.Top -> outInsets.top += shadowClipping
+                        LabelPosition.Bottom -> outInsets.bottom += shadowClipping
+                        LabelPosition.AroundPoint, LabelPosition.AbovePoint -> Unit
+                    }
                 }
             }
         }

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
@@ -122,29 +122,39 @@ public open class DefaultCartesianMarker(
             val tickPosition: MarkerCorneredShape.TickPosition
             val y: Float
             val verticalPosition: VerticalPosition
-            if (labelPosition == LabelPosition.Top) {
-                tickPosition = MarkerCorneredShape.TickPosition.Bottom
-                y = context.chartBounds.top - label.tickSizeDp.pixels
-                verticalPosition = VerticalPosition.Top
-            } else {
-                val topPointY =
-                    targets.minOf { target ->
-                        when (target) {
-                            is CandlestickCartesianLayerMarkerTarget -> target.highCanvasY
-                            is ColumnCartesianLayerMarkerTarget ->
-                                target.columns.minOf(ColumnCartesianLayerMarkerTarget.Column::canvasY)
-                            is LineCartesianLayerMarkerTarget ->
-                                target.points.minOf(LineCartesianLayerMarkerTarget.Point::canvasY)
-                            else -> error("Unexpected `CartesianMarker.Target` implementation.")
+            when (labelPosition) {
+                LabelPosition.Top -> {
+                    tickPosition = MarkerCorneredShape.TickPosition.Bottom
+                    y = context.chartBounds.top - label.tickSizeDp.pixels
+                    verticalPosition = VerticalPosition.Top
+                }
+
+                LabelPosition.Bottom -> {
+                    tickPosition = MarkerCorneredShape.TickPosition.Top
+                    y = context.chartBounds.bottom + label.tickSizeDp.pixels
+                    verticalPosition = VerticalPosition.Bottom
+                }
+
+                LabelPosition.AroundPoint, LabelPosition.AbovePoint -> {
+                    val topPointY =
+                        targets.minOf { target ->
+                            when (target) {
+                                is CandlestickCartesianLayerMarkerTarget -> target.highCanvasY
+                                is ColumnCartesianLayerMarkerTarget ->
+                                    target.columns.minOf(ColumnCartesianLayerMarkerTarget.Column::canvasY)
+                                is LineCartesianLayerMarkerTarget ->
+                                    target.points.minOf(LineCartesianLayerMarkerTarget.Point::canvasY)
+                                else -> error("Unexpected `CartesianMarker.Target` implementation.")
+                            }
                         }
-                    }
-                val flip =
-                    labelPosition == LabelPosition.AroundPoint &&
-                        topPointY - labelBounds.height() - label.tickSizeDp.pixels < context.chartBounds.top
-                tickPosition =
-                    if (flip) MarkerCorneredShape.TickPosition.Top else MarkerCorneredShape.TickPosition.Bottom
-                y = topPointY + (if (flip) 1 else -1) * label.tickSizeDp.pixels
-                verticalPosition = if (flip) VerticalPosition.Bottom else VerticalPosition.Top
+                    val flip =
+                        labelPosition == LabelPosition.AroundPoint &&
+                            topPointY - labelBounds.height() - label.tickSizeDp.pixels < context.chartBounds.top
+                    tickPosition =
+                        if (flip) MarkerCorneredShape.TickPosition.Top else MarkerCorneredShape.TickPosition.Bottom
+                    y = topPointY + (if (flip) 1 else -1) * label.tickSizeDp.pixels
+                    verticalPosition = if (flip) VerticalPosition.Bottom else VerticalPosition.Top
+                }
             }
             extraStore[MarkerCorneredShape.tickPositionKey] = tickPosition
 
@@ -191,6 +201,11 @@ public open class DefaultCartesianMarker(
          * Positions the label at the top of the [CartesianChart]. Sufficient room is made.
          */
         Top,
+
+        /**
+         * Positions the label at the bottom of the [CartesianChart]. Sufficient room is made.
+         */
+        Bottom,
 
         /**
          * Positions the label above the topmost marked point or, if there isn’t enough room, below it.

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
@@ -192,13 +192,15 @@ public open class DefaultCartesianMarker(
         horizontalDimensions: HorizontalDimensions,
     ) {
         when (labelPosition) {
-            LabelPosition.Top, LabelPosition.AbovePoint -> with(context) {
-                outInsets.top = label.getHeight(context) + label.tickSizeDp.pixels
-            }
+            LabelPosition.Top, LabelPosition.AbovePoint ->
+                with(context) {
+                    outInsets.top = label.getHeight(context) + label.tickSizeDp.pixels
+                }
 
-            LabelPosition.Bottom -> with(context) {
-                outInsets.bottom = label.getHeight(context) + label.tickSizeDp.pixels
-            }
+            LabelPosition.Bottom ->
+                with(context) {
+                    outInsets.bottom = label.getHeight(context) + label.tickSizeDp.pixels
+                }
 
             LabelPosition.AroundPoint -> Unit // Will be inside the chart
         }

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
@@ -191,8 +191,17 @@ public open class DefaultCartesianMarker(
         outInsets: Insets,
         horizontalDimensions: HorizontalDimensions,
     ) {
-        if (labelPosition == LabelPosition.AroundPoint) return
-        with(context) { outInsets.top = label.getHeight(context) + label.tickSizeDp.pixels }
+        when (labelPosition) {
+            LabelPosition.Top, LabelPosition.AbovePoint -> with(context) {
+                outInsets.top = label.getHeight(context) + label.tickSizeDp.pixels
+            }
+
+            LabelPosition.Bottom -> with(context) {
+                outInsets.bottom = label.getHeight(context) + label.tickSizeDp.pixels
+            }
+
+            LabelPosition.AroundPoint -> Unit // Will be inside the chart
+        }
     }
 
     /** Specifies the position of a [DefaultCartesianMarker]’s label. */

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
@@ -191,18 +191,16 @@ public open class DefaultCartesianMarker(
         outInsets: Insets,
         horizontalDimensions: HorizontalDimensions,
     ) {
-        when (labelPosition) {
-            LabelPosition.Top, LabelPosition.AbovePoint ->
-                with(context) {
+        with(context) {
+            when (labelPosition) {
+                LabelPosition.Top, LabelPosition.AbovePoint ->
                     outInsets.top = label.getHeight(context) + label.tickSizeDp.pixels
-                }
 
-            LabelPosition.Bottom ->
-                with(context) {
+                LabelPosition.Bottom ->
                     outInsets.bottom = label.getHeight(context) + label.tickSizeDp.pixels
-                }
 
-            LabelPosition.AroundPoint -> Unit // Will be inside the chart
+                LabelPosition.AroundPoint -> Unit // Will be inside the chart
+            }
         }
     }
 


### PR DESCRIPTION
Adds `Bottom` as a `LabelPosition`, which positions at the bottom of the graph. Basically the inverse of `Top`.
Solves https://github.com/patrykandpatrick/vico/discussions/701

| Bottom | Top |
| --- | --- |
| <img width="400" alt="Screenshot 2024-05-22 at 14 09 20" src="https://github.com/patrykandpatrick/vico/assets/20290474/26e98c4e-a234-49e7-99df-286a7ceb3989"> | <img width="400" alt="Screenshot 2024-05-22 at 14 24 56" src="https://github.com/patrykandpatrick/vico/assets/20290474/d742a335-3d78-4cf1-97c2-6bebaabbd111"> |
