### PR TITLE
Dashed Path support for LineCartesianLayer

### DIFF
--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart3.kt
@@ -28,6 +28,7 @@ import com.patrykandpatrick.vico.R
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
+import com.patrykandpatrick.vico.compose.cartesian.layer.dashed
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLine
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
@@ -38,6 +39,7 @@ import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
 import com.patrykandpatrick.vico.compose.common.component.shapeComponent
 import com.patrykandpatrick.vico.compose.common.dimensions
 import com.patrykandpatrick.vico.compose.common.fill
+import com.patrykandpatrick.vico.compose.common.shader.horizontalGradient
 import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
 import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
@@ -46,6 +48,7 @@ import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
 import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.core.cartesian.marker.DefaultCartesianMarker
 import com.patrykandpatrick.vico.core.common.data.ExtraStore
+import com.patrykandpatrick.vico.core.common.shader.DynamicShader
 import com.patrykandpatrick.vico.core.common.shape.CorneredShape
 import com.patrykandpatrick.vico.databinding.Chart3Binding
 import com.patrykandpatrick.vico.sample.showcase.Defaults
@@ -88,7 +91,15 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer, modifier: 
           lineProvider =
             LineCartesianLayer.LineProvider.series(
               LineCartesianLayer.rememberLine(
-                remember { LineCartesianLayer.LineFill.single(fill(lineColor)) }
+                fill =
+                  LineCartesianLayer.LineFill.single(
+                    fill(
+                      DynamicShader.horizontalGradient(
+                        arrayOf(Color(LINE_COLOR_1), Color(LINE_COLOR_2))
+                      )
+                    )
+                  ),
+                stroke = LineCartesianLayer.LineStroke.dashed(),
               )
             ),
           rangeProvider = rangeProvider,
@@ -102,7 +113,7 @@ private fun ComposeChart3(modelProducer: CartesianChartModelProducer, modifier: 
                 color = Color.Black,
                 margins = dimensions(end = 4.dp),
                 padding = dimensions(8.dp, 2.dp),
-                background = rememberShapeComponent(fill(lineColor), CorneredShape.Pill),
+                background = rememberShapeComponent(fill(Color(LINE_COLOR_1)), CorneredShape.Pill),
               ),
             title = stringResource(R.string.y_axis),
           ),
@@ -136,12 +147,26 @@ private fun ViewChart3(modelProducer: CartesianChartModelProducer, modifier: Mod
   AndroidViewBinding(Chart3Binding::inflate, modifier) {
     chartView.modelProducer = modelProducer
     val chart = requireNotNull(chartView.chart)
-    val lineLayer = (chart.layers[0] as LineCartesianLayer).copy(rangeProvider = rangeProvider)
+    val lineLayer =
+      (chart.layers[0] as LineCartesianLayer).copy(
+        rangeProvider = rangeProvider,
+        lineProvider =
+          LineCartesianLayer.LineProvider.series(
+            LineCartesianLayer.Line(
+              fill =
+                LineCartesianLayer.LineFill.single(
+                  fill(DynamicShader.horizontalGradient(LINE_COLOR_1, LINE_COLOR_2))
+                ),
+              stroke = LineCartesianLayer.LineStroke.Dashed(),
+            )
+          ),
+      )
     chartView.chart = chart.copy(lineLayer, marker = marker)
   }
 }
 
-private val lineColor = Color(0xffffbb00)
+private const val LINE_COLOR_1 = 0xffffbb00.toInt()
+private const val LINE_COLOR_2 = 0xffff4888.toInt()
 private val bottomAxisLabelBackgroundColor = Color(0xff9db591)
 private val rangeProvider =
   object : CartesianLayerRangeProvider {

--- a/sample/src/main/res/values/chart_3_styles.xml
+++ b/sample/src/main/res/values/chart_3_styles.xml
@@ -62,6 +62,8 @@
 
     <style name="Chart3Line1Style">
         <item name="android:color">@color/chart_3_color_1</item>
+        <item name="dashLength">4dp</item>
+        <item name="gapLength">8dp</item>
     </style>
 
     <style name="Chart3StartAxisTitleBackgroundStyle" parent="Chart3AxisTitleBackgroundStyle">

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/layer/LineCartesianLayer.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/layer/LineCartesianLayer.kt
@@ -95,9 +95,8 @@ public fun LineCartesianLayer.Companion.rememberLine(
     vicoTheme.lineCartesianLayerColors.first().let { color ->
       remember(color) { LineCartesianLayer.LineFill.single(fill(color)) }
     },
-  thickness: Dp = Defaults.LINE_SPEC_THICKNESS_DP.dp,
+  stroke: LineCartesianLayer.LineStroke = LineCartesianLayer.LineStroke.continuous(),
   areaFill: LineCartesianLayer.AreaFill? = remember(fill) { fill.getDefaultAreaFill() },
-  cap: StrokeCap = StrokeCap.Round,
   pointProvider: LineCartesianLayer.PointProvider? = null,
   pointConnector: LineCartesianLayer.PointConnector = remember {
     LineCartesianLayer.PointConnector.cubic()
@@ -109,9 +108,8 @@ public fun LineCartesianLayer.Companion.rememberLine(
 ): LineCartesianLayer.Line =
   remember(
     fill,
-    thickness,
+    stroke,
     areaFill,
-    cap,
     pointProvider,
     pointConnector,
     dataLabel,
@@ -121,9 +119,8 @@ public fun LineCartesianLayer.Companion.rememberLine(
   ) {
     LineCartesianLayer.Line(
       fill,
-      thickness.value,
+      stroke,
       areaFill,
-      cap.paintCap,
       pointProvider,
       pointConnector,
       dataLabel,
@@ -150,3 +147,24 @@ private val StrokeCap.paintCap: Paint.Cap
           "Not `StrokeCap.Butt`, `StrokeCap.Round`, or `StrokeCap.Square`."
         )
     }
+
+/** Creates a [LineCartesianLayer.LineStroke.Continuous] instance. */
+public fun LineCartesianLayer.LineStroke.Companion.continuous(
+  thickness: Dp = Defaults.LINE_SPEC_THICKNESS_DP.dp,
+  cap: StrokeCap = StrokeCap.Round,
+): LineCartesianLayer.LineStroke.Continuous =
+  LineCartesianLayer.LineStroke.Continuous(thickness.value, cap.paintCap)
+
+/** Creates a [LineCartesianLayer.LineStroke.Dashed] instance. */
+public fun LineCartesianLayer.LineStroke.Companion.dashed(
+  thickness: Dp = Defaults.LINE_SPEC_THICKNESS_DP.dp,
+  cap: StrokeCap = StrokeCap.Round,
+  dashLength: Dp = Defaults.LINE_PATTERN_DASHED_LENGTH.dp,
+  gapLength: Dp = Defaults.LINE_PATTERN_DASHED_GAP.dp,
+): LineCartesianLayer.LineStroke.Dashed =
+  LineCartesianLayer.LineStroke.Dashed(
+    thickness.value,
+    cap.paintCap,
+    dashLength.value,
+    gapLength.value,
+  )

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/common/Defaults.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/common/Defaults.kt
@@ -49,6 +49,8 @@ public object Defaults {
   public const val HOLLOW_CANDLE_STROKE_THICKNESS_DP: Float = 1f
   public const val CANDLE_SPACING_DP: Float = 4f
   public const val LINE_CURVATURE: Float = 0.5f
+  public const val LINE_PATTERN_DASHED_LENGTH: Float = 4f
+  public const val LINE_PATTERN_DASHED_GAP: Float = 8f
   public const val DASH_LENGTH: Float = 4f
   public const val DASH_GAP: Float = 2f
   public const val FADING_EDGE_VISIBILITY_THRESHOLD_DP: Float = 16f

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/theme/ComponentStyle.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/theme/ComponentStyle.kt
@@ -19,6 +19,7 @@ package com.patrykandpatrick.vico.views.common.theme
 import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.Color
+import android.graphics.Paint
 import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.core.common.DefaultAlpha
 import com.patrykandpatrick.vico.core.common.Defaults
@@ -160,6 +161,12 @@ internal fun TypedArray.getLine(context: Context, defaultColor: Int): LineCartes
       ),
     )
 
+  val dashLength = getRawDimension(context, R.styleable.LineStyle_dashLength, 0f)
+  val dashGap = getRawDimension(context, R.styleable.LineStyle_gapLength, 0f)
+  val thicknessDp =
+    getRawDimension(context, R.styleable.LineStyle_thickness, Defaults.LINE_SPEC_THICKNESS_DP)
+  val cap = Paint.Cap.entries[getInteger(R.styleable.LineStyle_android_strokeLineCap, 1)]
+
   return LineCartesianLayer.Line(
     fill =
       if (positiveLineColor != negativeLineColor) {
@@ -167,8 +174,6 @@ internal fun TypedArray.getLine(context: Context, defaultColor: Int): LineCartes
       } else {
         LineCartesianLayer.LineFill.single(Fill(positiveLineColor))
       },
-    thicknessDp =
-      getRawDimension(context, R.styleable.LineStyle_thickness, Defaults.LINE_SPEC_THICKNESS_DP),
     areaFill =
       LineCartesianLayer.AreaFill.double(
         Fill(DynamicShader.verticalGradient(positiveGradientTopColor, positiveGradientBottomColor)),
@@ -203,5 +208,11 @@ internal fun TypedArray.getLine(context: Context, defaultColor: Int): LineCartes
     dataLabelVerticalPosition =
       VerticalPosition.entries[getInteger(R.styleable.LineStyle_dataLabelVerticalPosition, 0)],
     dataLabelRotationDegrees = getFloat(R.styleable.LineStyle_dataLabelRotationDegrees, 0f),
+    stroke =
+      if (dashLength > 0f && dashGap > 0f) {
+        LineCartesianLayer.LineStroke.Dashed(thicknessDp, cap, dashLength, dashGap)
+      } else {
+        LineCartesianLayer.LineStroke.Continuous(thicknessDp, cap)
+      },
   )
 }

--- a/vico/views/src/main/res/values/attrs.xml
+++ b/vico/views/src/main/res/values/attrs.xml
@@ -27,6 +27,8 @@
     <attr name="strokeColor" format="color" />
     <attr name="strokeThickness" format="dimension" />
     <attr name="thickness" format="dimension" />
+    <attr name="dashLength" format="dimension" />
+    <attr name="gapLength" format="dimension" />
 
     <declare-styleable name="AxisStyle">
         <!-- Equivalent to the `addExtremeLabel` parameter of
@@ -486,6 +488,9 @@
         line. -->
         <attr name="dataLabelVerticalPosition" />
 
+        <!-- The line stroke cap. -->
+        <attr name="android:strokeLineCap"/>
+
         <!-- The bottom color of the vertical background gradient. -->
         <attr name="gradientBottomColor" format="color" />
 
@@ -521,6 +526,12 @@
 
         <!-- The stroke thickness. -->
         <attr name="thickness" />
+
+        <!-- The dash length. 0 means no dashes. -->
+        <attr name="dashLength" />
+
+        <!-- The dash gap length. 0 means no dashes. -->
+        <attr name="gapLength" />
     </declare-styleable>
 
     <declare-styleable name="ShapeStyle">
@@ -552,10 +563,10 @@
         </attr>
 
         <!-- The dash length. 0 means no dashes. -->
-        <attr name="dashLength" format="dimension" />
+        <attr name="dashLength" />
 
         <!-- The dash gap length. 0 means no dashes. -->
-        <attr name="gapLength" format="dimension" />
+        <attr name="gapLength" />
 
         <!-- The size of the top-end corner. -->
         <attr name="topEndCornerSize" format="dimension|fraction" />


### PR DESCRIPTION
# Description
This pull request enables users to add a `android.graphics.DashPathEffect` to the `LineCartesianLayer`. It adds a `LinePattern` sealed interface for `LineCartesianLayer` to add dashed line pattern support along with continuous line pattern.

# Why?
Occasionally, the design team may require a dashed pattern for the lines on the Line Layer. There's also an ongoing discussion about adding support for a Dashed Line 
- Previous attempt: #677 , my apologies for not being able to address the comments on time.
- Open discussion: #469 

With this update, users can choose a `LinePattern` between `Continuous` (default) and `Dashed`

# How?
First, I added a sealed interface `LinePattern` containing two implementation `Continuous` and `Dashed` addressing this [comment](https://github.com/patrykandpatrick/vico/pull/677#issuecomment-2105937285) from the previous PR. Then I added it as a property for `Line` in `/core/cartesian/layer/LineCartesianLayer.kt` class. Utilizing the library's extensive APIs, I assigned these patterns to `pathEffect` using `linePaint` within the `draw()` function.

Next, I updated the `rememberLine()` function in `/compose/cartesian/layer/LineCartesianLayer.kt` to include the `pattern` property. I also added compose factory methods for `continuous()` and `dashed()` so that we can use `Dp` in Compose, addressing this [comment](https://github.com/patrykandpatrick/vico/pull/677#issuecomment-2105937285) 

And finally, I updated the sample application by using the `pattern` property on `Chart3` (as suggested [here](https://github.com/patrykandpatrick/vico/pull/677#pullrequestreview-2035396974)). This shows how simple it is to add a new line pattern.

# What does that look like?

| Default Behavior | with `Dashed` line pattern |
| ---| ---|
| <img src="https://github.com/user-attachments/assets/7132157e-0a70-4cab-823e-5b46cf79318e" width=250 height=550/> | <img src="https://github.com/user-attachments/assets/acd277b3-329f-471d-bc0f-05df2228b170" width=250 height=550/> |

| Default Behavior | with `Dashed` line pattern |
| ---| ---|
| <video src="https://github.com/user-attachments/assets/bdcaaba8-2591-470e-9c8f-f459d03e8b2e"/> | <video src="https://github.com/user-attachments/assets/010a339e-f9ab-43eb-8af7-81761b35ad81"/> |

<details>

<summary>Known issues ✅ </summary>

# Known issues:
I have encountered a couple of issues that I haven't been able to fully resolve:

- ✅  **Shifting dashes on scroll**: As pointed out by @patrickmichalik in this [comment](https://github.com/patrykandpatrick/vico/pull/677#issuecomment-2105937285), `LineCartesianLayer` optimizes performance by rendering only the visible portion of each line. While this works well for continuous lines, it causes the dashes to shift when scrolling, as the dash pattern resets based on the visible section. Given my limited understanding of the APIs, ~I haven't found a way to fix this yet.~ Fixed in [1817969](https://github.com/patrykandpatrick/vico/pull/870/commits/181796993ef1a09e6832ebc9857f143a4bc30ada)

**This issue can be ignored as the fix is already being made by the authors - see [comment](https://github.com/patrykandpatrick/vico/pull/870#issuecomment-2351111820)**
>~- ✅  **Markers Falling on Dash Gaps**: While updating `Chart3`, I noticed that the `Marker` can appear empty when it falls on a dash gap. This occurs because the marker's position lands where no path is drawn. A possible fix could involve using `PathDashPathEffect` to draw a transparent underlying path with the dashed path overlaid on top, ensuring the marker always has a valid Entry to read the value from. However, I'm unsure if this approach is optimal or merely a workaround.
<img src="https://github.com/user-attachments/assets/4131992f-3dce-4720-b497-dec1fd1e7c99" width=250 height=550/>~

I’d appreciate any guidance or feedback on how to best address these issues, as they are crucial to ensuring smooth functionality. I understand this PR is incomplete without addressing these, I intend to get the ball rolling to add this functionality to this already amazing library. 🙌  If you plan to address this your way, please feel free to close this PR in favor of your implementation.

</details>

Please feel free to make any changes as you see fit!

Thank you!
