### PR TITLE
Feature/marker on tap event

### DIFF
--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Charts.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Charts.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.patrykandpatrick.vico.sample.showcase.charts.Chart1
 import com.patrykandpatrick.vico.sample.showcase.charts.Chart10
+import com.patrykandpatrick.vico.sample.showcase.charts.Chart11
 import com.patrykandpatrick.vico.sample.showcase.charts.Chart2
 import com.patrykandpatrick.vico.sample.showcase.charts.Chart3
 import com.patrykandpatrick.vico.sample.showcase.charts.Chart4
@@ -41,4 +42,5 @@ internal val charts =
     { uiFramework, modifier -> Chart8(uiFramework, modifier) },
     { uiFramework, modifier -> Chart9(uiFramework, modifier) },
     { uiFramework, modifier -> Chart10(uiFramework, modifier) },
+    { uiFramework, modifier -> Chart11(uiFramework, modifier) },
   )

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart11.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart11.kt
@@ -89,7 +89,15 @@ private fun ComposeChart11(
   series: List<Float>,
 ) {
   val currentSelectedIndex = remember { mutableIntStateOf(series.lastIndex) }
+  val marker = remember { CustomMarker() }
 
+  val selectedBarListener = remember(series.size) {
+    object : CartesianMarkerVisibilityListener {
+      override fun onTap(marker: CartesianMarker, targets: List<CartesianMarker.Target>) {
+        currentSelectedIndex.intValue = targets.first().x.toInt()
+      }
+    }
+  }
 
   val columnProvider = remember {
     object : ColumnCartesianLayer.ColumnProvider {
@@ -118,7 +126,9 @@ private fun ComposeChart11(
     }
   }
 
-  val marker = remember { CustomMarker() }
+  val cartesianLayer = rememberColumnCartesianLayer(
+    columnProvider = columnProvider,
+  )
 
   val persistentMarkers = rememberExtraLambda<PersistentMarkerScope>(
     currentSelectedIndex.intValue,
@@ -126,20 +136,10 @@ private fun ComposeChart11(
     marker at currentSelectedIndex.intValue
   }
 
-  val selectedBarListener = remember(series.size) {
-    object : CartesianMarkerVisibilityListener {
-      override fun onTap(marker: CartesianMarker, targets: List<CartesianMarker.Target>) {
-        currentSelectedIndex.intValue = targets.first().x.toInt()
-      }
-    }
-  }
-
   CartesianChartHost(
     chart =
     rememberCartesianChart(
-      rememberColumnCartesianLayer(
-        columnProvider = columnProvider,
-      ),
+      cartesianLayer,
       startAxis = VerticalAxis.rememberStart(),
       bottomAxis =
       HorizontalAxis.rememberBottom(
@@ -202,7 +202,7 @@ private fun ViewChart11(
     }
   }
 
-  val layer = rememberColumnCartesianLayer(
+  val cartesianLayer = rememberColumnCartesianLayer(
     columnProvider = columnProvider,
   )
 
@@ -225,7 +225,7 @@ private fun ViewChart11(
             marker = marker,
             persistentMarkers = persistentMarkers,
             markerVisibilityListener = selectedBarListener,
-            layers = arrayOf(layer),
+            layers = arrayOf(cartesianLayer),
           )
         }
       }

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart11.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart11.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.sample.showcase.charts
+
+/*
+ * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.viewinterop.AndroidViewBinding
+import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberColumnCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.core.cartesian.CartesianChart
+import com.patrykandpatrick.vico.core.cartesian.CartesianDrawingContext
+import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
+import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
+import com.patrykandpatrick.vico.core.cartesian.data.ColumnCartesianLayerModel
+import com.patrykandpatrick.vico.core.cartesian.data.columnSeries
+import com.patrykandpatrick.vico.core.cartesian.layer.ColumnCartesianLayer
+import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarker
+import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarkerVisibilityListener
+import com.patrykandpatrick.vico.core.common.component.LineComponent
+import com.patrykandpatrick.vico.core.common.data.ExtraStore
+import com.patrykandpatrick.vico.databinding.Chart2Binding
+import com.patrykandpatrick.vico.sample.showcase.UIFramework
+import com.patrykandpatrick.vico.sample.showcase.rememberMarker
+import java.text.DateFormatSymbols
+import java.util.Locale
+import kotlin.random.Random
+
+@Composable
+internal fun Chart11(uiFramework: UIFramework, modifier: Modifier) {
+  val modelProducer = remember { CartesianChartModelProducer() }
+  val series = List(47) { 2 + Random.nextFloat() * 18 }
+  LaunchedEffect(Unit) {
+    modelProducer.runTransaction {
+      columnSeries { series(series) }
+    }
+  }
+  when (uiFramework) {
+    UIFramework.Compose -> ComposeChart11(modelProducer, modifier, series)
+    UIFramework.Views -> ViewChart11(modelProducer, modifier)
+  }
+}
+
+@Composable
+private fun ComposeChart11(
+  modelProducer: CartesianChartModelProducer,
+  modifier: Modifier,
+  series: List<Float>,
+) {
+  val currentSelectedIndex = remember { mutableIntStateOf(series.lastIndex) }
+
+  val color = remember { Color.Blue }
+  val selectedColor = remember { Color.Green }
+  val barThickness = remember { 10f }
+
+  val columnProvider = remember {
+    object : ColumnCartesianLayer.ColumnProvider {
+      override fun getColumn(
+        entry: ColumnCartesianLayerModel.Entry,
+        seriesIndex: Int,
+        extraStore: ExtraStore,
+      ): LineComponent {
+        val barColor = if (entry.x.toInt() == currentSelectedIndex.intValue) {
+          selectedColor
+        } else {
+          color
+        }
+        return LineComponent(
+          color = barColor.toArgb(),
+          thicknessDp = barThickness,
+        )
+      }
+
+      override fun getWidestSeriesColumn(seriesIndex: Int, extraStore: ExtraStore): LineComponent {
+        return LineComponent(
+          color = color.toArgb(),
+          thicknessDp = barThickness,
+        )
+      }
+    }
+  }
+
+  val invisibleMarker = remember {
+    object : CartesianMarker {
+      override val displayOnTap: Boolean
+        get() = true
+
+      override fun draw(context: CartesianDrawingContext, targets: List<CartesianMarker.Target>) {}
+    }
+  }
+
+  val persistentMarkers = remember(currentSelectedIndex.intValue) {
+    mutableStateOf<(CartesianChart.PersistentMarkerScope.(ExtraStore) -> Unit)>(
+      {
+        invisibleMarker at currentSelectedIndex.intValue
+      },
+    )
+  }
+
+  val selectedBarListener = remember(series.size) {
+    object : CartesianMarkerVisibilityListener {
+      override fun onTap(marker: CartesianMarker, targets: List<CartesianMarker.Target>) {
+        currentSelectedIndex.intValue = targets.first().x.toInt()
+      }
+    }
+  }
+
+  CartesianChartHost(
+    chart =
+    rememberCartesianChart(
+      rememberColumnCartesianLayer(
+        columnProvider = columnProvider,
+      ),
+      startAxis = VerticalAxis.rememberStart(),
+      bottomAxis =
+      HorizontalAxis.rememberBottom(
+        valueFormatter = bottomAxisValueFormatter,
+        itemPlacer =
+        remember {
+          HorizontalAxis.ItemPlacer.aligned(spacing = 3, addExtremeLabelPadding = true)
+        },
+      ),
+      marker = invisibleMarker,
+      persistentMarkers = persistentMarkers.value,
+      markerVisibilityListener = selectedBarListener,
+    ),
+    modelProducer = modelProducer,
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun ViewChart11(modelProducer: CartesianChartModelProducer, modifier: Modifier) {
+  val marker = rememberMarker()
+  AndroidViewBinding(
+    { inflater, parent, attachToParent ->
+      Chart2Binding.inflate(inflater, parent, attachToParent).apply {
+        with(chartView) {
+          this.modelProducer = modelProducer
+          chart = chart?.copy(
+            bottomAxis =
+            (chart?.bottomAxis as HorizontalAxis).copy(
+              valueFormatter = bottomAxisValueFormatter,
+            ),
+            marker = marker,
+          )
+        }
+      }
+    },
+    modifier,
+  )
+}
+
+private val monthNames = DateFormatSymbols.getInstance(Locale.US).shortMonths
+private val bottomAxisValueFormatter = CartesianValueFormatter { _, x, _ ->
+  "${monthNames[x.toInt() % 12]} ’${20 + x.toInt() / 12}"
+}

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -139,6 +139,7 @@ internal fun CartesianChartHostImpl(
 ) {
   val canvasBounds = remember { RectF() }
   val markerTouchPoint = remember { mutableStateOf<Point?>(null) }
+  val markerTapPoint = remember { mutableStateOf<Point?>(null) }
   val displayMarkerOnTap = remember { mutableStateOf(chart.marker?.displayOnTap ?: false) }
 
   val measuringContext =
@@ -178,7 +179,7 @@ internal fun CartesianChartHostImpl(
         },
         setTapPoint = if (displayMarkerOnTap.value) {
           remember(chart.marker == null) {
-            if (chart.marker != null) markerTouchPoint.component2() else null
+            if (chart.marker != null) markerTapPoint.component2() else null
           }
         } else {
           null
@@ -229,9 +230,10 @@ internal fun CartesianChartHostImpl(
         zoom = zoomState.value,
       )
 
-    chart.draw(drawingContext, markerTouchPoint.value, displayMarkerOnTap.value)
     if (displayMarkerOnTap.value) {
-      markerTouchPoint.value = null
+      chart.draw(drawingContext, markerTapPoint.value, displayMarkerOnTap.value)
+    } else{
+      chart.draw(drawingContext, markerTouchPoint.value, displayMarkerOnTap.value)
     }
 
     measuringContext.reset()

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/TouchEvent.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/TouchEvent.kt
@@ -18,6 +18,7 @@ package com.patrykandpatrick.vico.compose.cartesian
 
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -28,16 +29,17 @@ import com.patrykandpatrick.vico.core.common.Point
 
 internal fun Modifier.chartTouchEvent(
   setTouchPoint: ((Point?) -> Unit)?,
+  setTapPoint: ((Point?) -> Unit)?,
   isScrollEnabled: Boolean,
   scrollState: VicoScrollState,
   onZoom: ((Float, Offset) -> Unit)?,
 ): Modifier =
   scrollable(
-      state = scrollState.scrollableState,
-      orientation = Orientation.Horizontal,
-      reverseDirection = true,
-      enabled = isScrollEnabled,
-    )
+    state = scrollState.scrollableState,
+    orientation = Orientation.Horizontal,
+    reverseDirection = true,
+    enabled = isScrollEnabled,
+  )
     .then(
       if (setTouchPoint != null) {
         pointerInput(setTouchPoint) {
@@ -51,9 +53,17 @@ internal fun Modifier.chartTouchEvent(
             }
           }
         }
+      } else if (setTapPoint != null) {
+        pointerInput(setTapPoint) {
+          detectTapGestures(
+            onTap = { offset ->
+              setTapPoint(offset.point)
+            },
+          )
+        }
       } else {
         Modifier
-      }
+      },
     )
     .then(
       if (!isScrollEnabled && setTouchPoint != null) {
@@ -68,7 +78,7 @@ internal fun Modifier.chartTouchEvent(
         }
       } else {
         Modifier
-      }
+      },
     )
     .then(
       if (isScrollEnabled && onZoom != null) {
@@ -80,7 +90,7 @@ internal fun Modifier.chartTouchEvent(
         }
       } else {
         Modifier
-      }
+      },
     )
 
 private val Offset.point: Point

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/CartesianChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/CartesianChart.kt
@@ -89,7 +89,6 @@ public open class CartesianChart(
   }
   private var previousPersistentMarkerHashCode: Int? = null
   private var lastTapPosition: Point? = null
-  private var lastScroll: Float? = null
   private val insets = Insets()
   private val axisManager = AxisManager()
   private val _markerTargets = sortedMapOf<Double, MutableList<CartesianMarker.Target>>()
@@ -368,7 +367,6 @@ public open class CartesianChart(
       marker.draw(context, targets)
       markerVisibilityListener?.onTap(marker, targets)
       lastTapPosition = pointerPosition
-      lastScroll = context.scroll
     } else {
       marker.draw(context, targets)
       val targetHashCode = targets.hashCode()

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/CartesianChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/CartesianChart.kt
@@ -88,6 +88,8 @@ public open class CartesianChart(
     persistentMarkerMap[it.toDouble()] = this
   }
   private var previousPersistentMarkerHashCode: Int? = null
+  private var lastTapPosition: Point? = null
+  private var lastScroll: Float? = null
   private val insets = Insets()
   private val axisManager = AxisManager()
   private val _markerTargets = sortedMapOf<Double, MutableList<CartesianMarker.Target>>()
@@ -354,15 +356,21 @@ public open class CartesianChart(
     var previousDistance = Float.POSITIVE_INFINITY
     for (xTargets in markerTargets.values) {
       val (distance, canvasXTargets) =
-        xTargets.groupBy { abs(pointerPosition.x - it.canvasX) }.minBy { it.key }
+        xTargets.groupBy {
+          abs(pointerPosition.x - it.canvasX)
+        }.minBy { it.key }
       if (distance > previousDistance) break
       targets = canvasXTargets
       previousDistance = distance
     }
-    marker.draw(context, targets)
     if (displayMarkerOnTap) {
+      if (lastTapPosition == pointerPosition) return
+      marker.draw(context, targets)
       markerVisibilityListener?.onTap(marker, targets)
+      lastTapPosition = pointerPosition
+      lastScroll = context.scroll
     } else {
+      marker.draw(context, targets)
       val targetHashCode = targets.hashCode()
       if (previousMarkerTargetHashCode == null) {
         markerVisibilityListener?.onShown(marker, targets)

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/CartesianMarker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/CartesianMarker.kt
@@ -23,6 +23,8 @@ import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModel
 
 /** Marks [CartesianChart] objects. */
 public interface CartesianMarker : CartesianLayerInsetter<CartesianChartModel> {
+  public val displayOnTap: Boolean
+
   /** Draws the [CartesianMarker] for the specified [Target]s. */
   public fun draw(context: CartesianDrawingContext, targets: List<Target>)
 

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/CartesianMarkerVisibilityListener.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/CartesianMarkerVisibilityListener.kt
@@ -24,6 +24,9 @@ public interface CartesianMarkerVisibilityListener {
   /** Called when the specified [CartesianMarker]’s [CartesianMarker.Target]s change. */
   public fun onUpdated(marker: CartesianMarker, targets: List<CartesianMarker.Target>) {}
 
+  /** Called when a tap on [CartesianMarker.Target]s is registered. */
+  public fun onTap(marker: CartesianMarker, targets: List<CartesianMarker.Target>) {}
+
   /** Called when the specified [CartesianMarker] is hidden. */
   public fun onHidden(marker: CartesianMarker) {}
 }

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
@@ -57,6 +57,9 @@ public open class DefaultCartesianMarker(
   protected val indicatorSizeDp: Float = Defaults.MARKER_INDICATOR_SIZE,
   protected val guideline: LineComponent? = null,
 ) : CartesianMarker {
+  override val displayOnTap: Boolean
+    get() = false
+
   protected val tempBounds: RectF = RectF()
 
   protected val markerCorneredShape: MarkerCorneredShape? =
@@ -87,11 +90,13 @@ public open class DefaultCartesianMarker(
             drawIndicator(target.canvasX, target.lowCanvasY, target.lowColor, halfIndicatorSize)
             drawIndicator(target.canvasX, target.highCanvasY, target.highColor, halfIndicatorSize)
           }
+
           is ColumnCartesianLayerMarkerTarget -> {
             target.columns.forEach { column ->
               drawIndicator(target.canvasX, column.canvasY, column.color, halfIndicatorSize)
             }
           }
+
           is LineCartesianLayerMarkerTarget -> {
             target.points.forEach { point ->
               drawIndicator(target.canvasX, point.canvasY, point.color, halfIndicatorSize)
@@ -147,27 +152,32 @@ public open class DefaultCartesianMarker(
           y = context.layerBounds.top - tickSizeDp.pixels
           verticalPosition = VerticalPosition.Top
         }
+
         LabelPosition.Bottom -> {
           tickPosition = MarkerCorneredShape.TickPosition.Top
           y = context.layerBounds.bottom + tickSizeDp.pixels
           verticalPosition = VerticalPosition.Bottom
         }
+
         LabelPosition.AroundPoint,
-        LabelPosition.AbovePoint -> {
+        LabelPosition.AbovePoint,
+        -> {
           val topPointY =
             targets.minOf { target ->
               when (target) {
                 is CandlestickCartesianLayerMarkerTarget -> target.highCanvasY
                 is ColumnCartesianLayerMarkerTarget ->
                   target.columns.minOf(ColumnCartesianLayerMarkerTarget.Column::canvasY)
+
                 is LineCartesianLayerMarkerTarget ->
                   target.points.minOf(LineCartesianLayerMarkerTarget.Point::canvasY)
+
                 else -> error("Unexpected `CartesianMarker.Target` implementation.")
               }
             }
           val flip =
             labelPosition == LabelPosition.AroundPoint &&
-              topPointY - labelBounds.height() - tickSizeDp.pixels < context.layerBounds.top
+                topPointY - labelBounds.height() - tickSizeDp.pixels < context.layerBounds.top
           tickPosition =
             if (flip) MarkerCorneredShape.TickPosition.Top
             else MarkerCorneredShape.TickPosition.Bottom
@@ -214,10 +224,13 @@ public open class DefaultCartesianMarker(
     with(context) {
       when (labelPosition) {
         LabelPosition.Top,
-        LabelPosition.AbovePoint ->
+        LabelPosition.AbovePoint,
+        ->
           insets.ensureValuesAtLeast(top = label.getHeight(context) + tickSizeDp.pixels)
+
         LabelPosition.Bottom ->
           insets.ensureValuesAtLeast(bottom = label.getHeight(context) + tickSizeDp.pixels)
+
         LabelPosition.AroundPoint -> Unit // Will be inside the chart
       }
     }

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
@@ -83,6 +83,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   private val scaleGestureDetector = ScaleGestureDetector(context, scaleGestureListener)
 
   private var markerTouchPoint: Point? = null
+  private var markerTapPoint: Point? = null
 
   private var scrollDirectionResolved = false
 
@@ -114,6 +115,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
       scroller = scroller,
       density = resources.displayMetrics.density,
       onTouchPoint = ::handleTouchEvent,
+      onTapPoint = ::handelTapEvent,
       requestInvalidate = ::invalidate,
     )
 
@@ -298,6 +300,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
     invalidate()
   }
 
+  private fun handelTapEvent(point: Point?) {
+    markerTapPoint = point
+  }
+
   private fun handleTouchEvent(point: Point?) {
     markerTouchPoint = point
   }
@@ -332,9 +338,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
           zoom = zoomHandler.value,
         )
 
-      chart.draw(drawingContext, markerTouchPoint, chart.marker?.displayOnTap ?: false)
       if (chart.marker?.displayOnTap == true) {
-        markerTouchPoint = null
+        chart.draw(drawingContext, markerTapPoint, chart.marker?.displayOnTap ?: false)
+      } else {
+        chart.draw(drawingContext, markerTouchPoint, chart.marker?.displayOnTap ?: false)
       }
 
       measuringContext.reset()

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/gesture/MotionEventHandler.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/gesture/MotionEventHandler.kt
@@ -32,6 +32,7 @@ internal class MotionEventHandler(
   density: Float,
   var scrollEnabled: Boolean = false,
   private val onTouchPoint: (Point?) -> Unit,
+  private val onTapPoint: (Point?) -> Unit,
   private val requestInvalidate: () -> Unit,
 ) {
   private val velocityUnits = (VELOCITY_PIXELS * density).toInt()
@@ -78,7 +79,6 @@ internal class MotionEventHandler(
             if (!displayMarkerOnTap) {
               onTouchPoint(motionEvent.point)
             }
-
             requestInvalidate()
             initialX = -dragThreshold
           }
@@ -96,8 +96,8 @@ internal class MotionEventHandler(
       MotionEvent.ACTION_CANCEL,
       MotionEvent.ACTION_UP,
       -> {
-        if (totalDragAmount < 15f) {
-          onTouchPoint(motionEvent.point)
+        if (displayMarkerOnTap && totalDragAmount < 15f) {
+          onTapPoint(motionEvent.point)
         }
         totalDragAmount = 0f
         if (!displayMarkerOnTap) {


### PR DESCRIPTION
### Description

This pr aims to add support for onTap events in order to track the last tap point on the chart. Also, it makes possible for a marker to be displayed only when a tap event occurs which was previously not achievable.

### Why?

This feature can be useful when a user needs to display a marker only on tap event and wants to avoid marker popping up on every touch event. For instance, such unwanted behaviour may occur while scrolling. 

For context: [#769 ](https://github.com/patrykandpatrick/vico/discussions/769#discussioncomment-10834453)

### How?

1. Adds a `displayOnTap` value inside `CartesianMarker` which by default is `false`. This can be changed only by creating a custom implementation of a marker and setting the value to `true`. Tap detection will work only if the `displayOnTap` is `true`.

2. Gesture detection

- For **Compose**, detect tap gesture by adding an another `pointerInput` modifier inside `TouchEvent`. Tap event is sent further through a dedicated callback.
- For **Android View,** detect tap gesture inside `MotionEventHandler` by listening for `MotionEvent.ACTION_UP` and checking the drag distance. Like before, tap event is sent further through a dedicated callback.
- Calls `chart.draw()` replacing `markerTouchPoint` with `markerTapPoint`.
- **Important thing to note is that tap event and touch event are mutual exclusive.** 

3. Drawing marker
- Adds `displayMarkerOnTap` parameter to `chart.draw()` and also to `drawMarker()`. It is used to figure out how and when the marker should be drawn and when to notify user about it. 
- `lastTapPosition` helps to avoid redrawing the marker on new chart item when user scrolls.

4. CartesianMarkerVisibilityListener
- Adds a `onTap(marker: CartesianMarker, targets: List<CartesianMarker.Target>)` callback to notify user that marker was drawn on a new position.

5. Adds `Chart11` to showcase this behaviour. 

**Note:**
In Android View version of `Chart11`, persistent markers do not update properly. Might be related to [#900](https://github.com/patrykandpatrick/vico/issues/900)

It may not be the most elegant solution but it does the job.