### PR TITLE
Add entryIndex to PointProvider.getPoint

### DIFF
--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/data/CartesianLayerModel.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/data/CartesianLayerModel.kt
@@ -90,10 +90,10 @@ internal fun List<CartesianLayerModel.Entry>.getXDeltaGcd(): Double {
   } ?: 1.0
 }
 
-internal inline fun <T : CartesianLayerModel.Entry> List<T>.forEachIn(
+internal inline fun <T : CartesianLayerModel.Entry> List<T>.forEachInIndexed(
   range: ClosedFloatingPointRange<Double>,
   padding: Int = 0,
-  action: (T, T?) -> Unit,
+  action: (index: Int, entry: T, nextEntry: T?) -> Unit,
 ) {
   var start = 0
   var end = 0
@@ -106,5 +106,5 @@ internal inline fun <T : CartesianLayerModel.Entry> List<T>.forEachIn(
   }
   start = (start - padding).coerceAtLeast(0)
   end = (end + padding).coerceAtMost(lastIndex)
-  (start..end).forEach { action(this[it], getOrNull(it + 1)) }
+  (start..end).forEach { action(it, this[it], getOrNull(it + 1)) }
 }

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/CandlestickCartesianLayer.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/CandlestickCartesianLayer.kt
@@ -29,7 +29,7 @@ import com.patrykandpatrick.vico.core.cartesian.data.CandlestickCartesianLayerMo
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartRanges
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.core.cartesian.data.MutableCartesianChartRanges
-import com.patrykandpatrick.vico.core.cartesian.data.forEachIn
+import com.patrykandpatrick.vico.core.cartesian.data.forEachInIndexed
 import com.patrykandpatrick.vico.core.cartesian.layer.CandlestickCartesianLayer.Candle
 import com.patrykandpatrick.vico.core.cartesian.marker.CandlestickCartesianLayerMarkerTarget
 import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarker
@@ -151,7 +151,7 @@ protected constructor(
     var candle: Candle
     val minBodyHeight = minCandleBodyHeightDp.pixels
 
-    model.series.forEachIn(ranges.minX..ranges.maxX) { entry, _ ->
+    model.series.forEachInIndexed(ranges.minX..ranges.maxX) { _, entry, _ ->
       candle = candles.getCandle(entry, model.extraStore)
       val candleInfo = drawingModel?.entries?.get(entry.x) ?: entry.toCandleInfo(yRange)
       val xSpacingMultiplier = ((entry.x - ranges.minX) / ranges.xStep).toFloat()

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/ColumnCartesianLayer.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/ColumnCartesianLayer.kt
@@ -29,7 +29,7 @@ import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.core.cartesian.data.ColumnCartesianLayerDrawingModel
 import com.patrykandpatrick.vico.core.cartesian.data.ColumnCartesianLayerModel
 import com.patrykandpatrick.vico.core.cartesian.data.MutableCartesianChartRanges
-import com.patrykandpatrick.vico.core.cartesian.data.forEachIn
+import com.patrykandpatrick.vico.core.cartesian.data.forEachInIndexed
 import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarker
 import com.patrykandpatrick.vico.core.cartesian.marker.ColumnCartesianLayerMarkerTarget
 import com.patrykandpatrick.vico.core.cartesian.marker.MutableColumnCartesianLayerMarkerTarget
@@ -160,7 +160,7 @@ protected constructor(
     model.series.forEachIndexed { index, entryCollection ->
       drawingStart = getDrawingStart(index, model.series.size, mergeMode) - scroll
 
-      entryCollection.forEachIn(ranges.minX..ranges.maxX) { entry, _ ->
+      entryCollection.forEachInIndexed(ranges.minX..ranges.maxX) { _, entry, _ ->
         val columnInfo = drawingModel?.getOrNull(index)?.get(entry.x)
         height =
           (columnInfo?.height ?: (abs(entry.y) / yRange.length)).toFloat() * layerBounds.height()


### PR DESCRIPTION
### Background

Broadly speaking, I would love to get more information in the functions which provide `CartesianLayerModel.Entry`.

The information I am most interested in is:
* The index of the entry within its `series`.
* The x-value in pixels which corresponds to the `CartesianLayerModel.Entry.x`.
* The y-value in pixels which corresponds to the `CartesianLayerModel.Entry.y`.

I was a little surprised to find that `seriesIndex` was not the index of the `CartesianLayerModel.Entry` within its `series` but more broadly the whole `series` index among other `series`.

This commit adds `entryIndex` to `PointProvider.getPoint` which behaves as I had expected `seriesIndex` to.

I think this value may be beneficial to add to other surfaces, like the marker visibility listener.

### Motivation

My implementation which brought the desire for these changes is a little particular.

I will first emphasize: the change of this commit isn't absolutely required for me, however, it is a nice optimization.

The other two things I am interested in which are not included in this commit: the x and y-value in pixels of the entry do feel like some change would be required.

In my implementation, I abstract the Vico implementation of a Cartesian chart behind a Composable which takes a generic `T: Number`. Of course, Vico uses simply `Double`, which is fine - however, I wanted my Composable to be able to use just any `Number`.

I use `PointProvider.getPoint` to associate the entry with a `LineCartesianLayer.Point` with what is effectively a `Map<T, LineCartesianLayer.Point>`. However, as the `entry.x` value is a `Double`, it cannot be used in this generic purpose without an unchecked cast. My implementation work-around here is to look at my series' x-values, and find the closest `T` to `entry.x`. However, if I had an integer `entryIndex`, I could use this to more efficiently look-up the correct `T` corresponding to the `entry`.

### Key Changes
* `forEachIn` to `forEachInIndexed`.
* Add `entryIndex` to `PointProvider.getPoint`.

### Alternatives

As previously mentioned, this change is not explicitly necessary for me - though it would make things easier.

I am also curious if it would be of interest to more broadly have something like an `EntryMetadata` object which could encapsulate, among other things, these 3 additions (entry index, x & y pixel coordinates of the entry) I have mentioned.