### PR TITLE
Update layerPadding to getLayerPadding w/ ExtraStore

### DIFF
--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart1.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart1.kt
@@ -83,7 +83,7 @@ private fun ComposeChart1(modelProducer: CartesianChartModelProducer, modifier: 
             itemPlacer = remember { HorizontalAxis.ItemPlacer.segmented() },
           ),
         marker = marker,
-        layerPadding = cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp),
+        layerPadding = { cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp) },
         persistentMarkers = rememberExtraLambda(marker) { marker at PERSISTENT_MARKER_X },
       ),
     modelProducer = modelProducer,

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart4.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart4.kt
@@ -117,7 +117,7 @@ private fun ComposeChart4(modelProducer: CartesianChartModelProducer, modifier: 
           ),
         endAxis = VerticalAxis.rememberEnd(),
         marker = rememberMarker(),
-        layerPadding = cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp),
+        layerPadding = { cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp) },
       ),
     modelProducer = modelProducer,
     modifier = modifier,

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart5.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart5.kt
@@ -120,7 +120,7 @@ private fun ComposeChart5(modelProducer: CartesianChartModelProducer, modifier: 
             itemPlacer = remember { HorizontalAxis.ItemPlacer.segmented() },
           ),
         marker = rememberMarker(),
-        layerPadding = cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp),
+        layerPadding = { cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp) },
       ),
     modelProducer = modelProducer,
     modifier = modifier,

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart6.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart6.kt
@@ -109,7 +109,7 @@ private fun ComposeChart6(modelProducer: CartesianChartModelProducer, modifier: 
             itemPlacer = remember { HorizontalAxis.ItemPlacer.segmented() },
           ),
         marker = rememberMarker(),
-        layerPadding = cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp),
+        layerPadding = { cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp) },
         decorations = listOf(rememberComposeHorizontalBox()),
       ),
     modelProducer = modelProducer,

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart7.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart7.kt
@@ -117,7 +117,7 @@ private fun ComposeChart7(modelProducer: CartesianChartModelProducer, modifier: 
         bottomAxis =
           HorizontalAxis.rememberBottom(itemPlacer = HorizontalAxis.ItemPlacer.segmented()),
         marker = rememberMarker(),
-        layerPadding = cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp),
+        layerPadding = { cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp) },
         legend = rememberLegend(),
       ),
     modelProducer = modelProducer,

--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart8.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/charts/Chart8.kt
@@ -123,7 +123,7 @@ private fun ComposeChart8(modelProducer: CartesianChartModelProducer, modifier: 
             itemPlacer = remember { HorizontalAxis.ItemPlacer.segmented() }
           ),
         marker = rememberMarker(),
-        layerPadding = cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp),
+        layerPadding = { cartesianLayerPadding(scalableStart = 16.dp, scalableEnd = 16.dp) },
       ),
     modelProducer = modelProducer,
     modifier = modifier,

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianChart.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianChart.kt
@@ -52,7 +52,7 @@ public fun rememberCartesianChart(
   bottomAxis: Axis<Axis.Position.Horizontal.Bottom>? = null,
   marker: CartesianMarker? = null,
   markerVisibilityListener: CartesianMarkerVisibilityListener? = null,
-  layerPadding: CartesianLayerPadding = cartesianLayerPadding(),
+  layerPadding: ((ExtraStore) -> CartesianLayerPadding) = { cartesianLayerPadding() },
   legend: Legend<CartesianMeasuringContext, CartesianDrawingContext>? = null,
   fadingEdges: FadingEdges? = null,
   decorations: List<Decoration> = emptyList(),

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -146,7 +146,8 @@ internal fun CartesianChartHostImpl(
       ranges = ranges,
       scrollEnabled = scrollState.scrollEnabled,
       zoomEnabled = scrollState.scrollEnabled && zoomState.zoomEnabled,
-      layerPadding = chart.layerPadding,
+      layerPadding =
+        remember(chart.layerPadding, model.extraStore) { chart.layerPadding(model.extraStore) },
       spToPx = with(LocalContext.current) { ::spToPx },
     )
 

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/CartesianChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/CartesianChart.kt
@@ -62,7 +62,7 @@ import kotlin.math.abs
  * @property layers the [CartesianLayer]s.
  * @property marker appears when the [CartesianChart] is tapped.
  * @property markerVisibilityListener allows for listening to [marker] visibility changes.
- * @property layerPadding stores the [CartesianLayer] padding values.
+ * @property layerPadding returns the [CartesianLayerPadding].
  * @property legend the legend.
  * @property fadingEdges applies a horizontal fade to the edges of the [CartesianChart], provided
  *   that it’s scrollable.
@@ -80,7 +80,7 @@ public open class CartesianChart(
   @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) public val marker: CartesianMarker? = null,
   protected val markerVisibilityListener: CartesianMarkerVisibilityListener? = null,
   @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-  public val layerPadding: CartesianLayerPadding = CartesianLayerPadding(),
+  public val layerPadding: ((ExtraStore) -> CartesianLayerPadding) = { CartesianLayerPadding() },
   protected val legend: Legend<CartesianMeasuringContext, CartesianDrawingContext>? = null,
   protected val fadingEdges: FadingEdges? = null,
   protected val decorations: List<Decoration> = emptyList(),
@@ -408,7 +408,7 @@ public open class CartesianChart(
     bottomAxis: Axis<Axis.Position.Horizontal.Bottom>? = this.bottomAxis,
     marker: CartesianMarker? = this.marker,
     markerVisibilityListener: CartesianMarkerVisibilityListener? = this.markerVisibilityListener,
-    layerPadding: CartesianLayerPadding = this.layerPadding,
+    layerPadding: ((ExtraStore) -> CartesianLayerPadding) = this.layerPadding,
     legend: Legend<CartesianMeasuringContext, CartesianDrawingContext>? = this.legend,
     fadingEdges: FadingEdges? = this.fadingEdges,
     decorations: List<Decoration> = this.decorations,

--- a/vico/core/src/test/java/com/patrykandpatrick/vico/core/cartesian/CartesianChartTest.kt
+++ b/vico/core/src/test/java/com/patrykandpatrick/vico/core/cartesian/CartesianChartTest.kt
@@ -71,7 +71,7 @@ public class CartesianChartTest {
   public fun `Given CartesianChart is copied with changes, when it is compared to the original, then they are NOT equal`() {
     val chart = getCartesianChart()
 
-    val copiedChart = chart.copy(layerPadding = CartesianLayerPadding(10f, 10f, 10f, 10f))
+    val copiedChart = chart.copy(layerPadding = { CartesianLayerPadding(10f, 10f, 10f, 10f) })
 
     Assertions.assertNotEquals(chart, copiedChart)
     Assertions.assertNotEquals(chart.hashCode(), copiedChart.hashCode())

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/theme/ThemeHandler.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/theme/ThemeHandler.kt
@@ -211,6 +211,7 @@ internal class ThemeHandler(private val context: Context, attrs: AttributeSet?) 
     val candlestickLayer =
       if (layerFlags.hasFlag(CANDLESTICK_LAYER)) typedArray.getCandlestickCartesianLayer(context)
       else null
+    val layerPadding = typedArray.getLayerPadding()
 
     return CartesianChart(
       layers =
@@ -225,7 +226,7 @@ internal class ThemeHandler(private val context: Context, attrs: AttributeSet?) 
       endAxis = typedArray.getAxis(Axis.Position.Vertical.End),
       bottomAxis = typedArray.getAxis(Axis.Position.Horizontal.Bottom),
       fadingEdges = typedArray.getFadingEdges(),
-      layerPadding = typedArray.getLayerPadding(),
+      layerPadding = { layerPadding },
     )
   }
 


### PR DESCRIPTION
### Background

This commit introduces CartesianLayerPaddingProvider, a means to retrieve CartesianLayerPadding with an `ExtraStore`. This commit does not substantially conflict with pre-existing functionality as `CartesianLayerPaddingProvider.fixed` is identical.

### Motivation

`CartesianLayerPadding` was recently added. This allows clients to provide padding to the start and end of a chart. However, these values are provided without an `ExtraStore`. Therefore, I believe that the values provided will never be synchronously safe.

With an `ExtraStore`, we can calculate the correct spacing safely.

### Future Work

The discovery of the desire to change this parameter came from some advanced requirements with points. 

https://github.com/patrykandpatrick/vico/discussions/939

I would like to move the horizontal and vertical insets achieved through `getLargestPoint` to being client-provided in `CartesianLayerPadding`. The basic demand for that is that currently, `getLargestPoint` + `unscalableStartPadding` can result in an unnecessary amount of padding. Further, imagine that we only had a point at the very middle of the graph. We should, in that case, not inset the chart at all to account for the point horizontally. We should do the top if it is the maximum value in the series.

So, I would also like to introduce `unscalableTopPadding` and `unscalableBottomPadding` and change `getLargestPoint` to only impact the point spacing.


### Note

I could be completely incorrect in the basic assertion here that this is necessary to correctly have synchronous padding: for example, to avoid a bad state if the padding, which is dependent on the line thickness, changes before the transaction finishes. Please correct me if I am wrong.