### PR TITLE
CubicPointConnector - Remove Impossible Logic

### DIFF
--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/CubicPointConnector.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/layer/CubicPointConnector.kt
@@ -34,15 +34,11 @@ internal data class CubicPointConnector(private val curvature: Float) :
     x2: Float,
     y2: Float,
   ) {
-    if (curvature == 0f) {
-      path.lineTo(x2, y2)
-    } else {
-      val xDelta =
-        (Y_MULTIPLIER * abs(y2 - y1) / context.layerBounds.height()).coerceAtMost(1f) *
-          curvature *
-          (x2 - x1)
-      path.cubicTo(x1 + xDelta, y1, x2 - xDelta, y2, x2, y2)
-    }
+    val xDelta =
+      (Y_MULTIPLIER * abs(y2 - y1) / context.layerBounds.height()).coerceAtMost(1f) *
+        curvature *
+        (x2 - x1)
+    path.cubicTo(x1 + xDelta, y1, x2 - xDelta, y2, x2, y2)
   }
 
   private companion object {


### PR DESCRIPTION
Recently, the constructor of `CubicPointConnector` was updated to produce a run-time crash when curvature is == 0.

This did not happen before, and as such, there is a piece of logic to handle the curvature == 0 case. This can now be removed.