### PR TITLE
Add BelowPoint to LabelPosition

### DIFF
--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/showcase/Marker.kt
@@ -126,7 +126,8 @@ internal fun rememberMarker(
           when (labelPosition) {
             LabelPosition.Top,
             LabelPosition.AbovePoint -> topMargin += label.getHeight(context) + tickSizeDp.pixels
-            LabelPosition.Bottom -> bottomMargin += label.getHeight(context) + tickSizeDp.pixels
+            LabelPosition.Bottom,
+            LabelPosition.BelowPoint -> bottomMargin += label.getHeight(context) + tickSizeDp.pixels
             LabelPosition.AroundPoint -> {}
           }
           layerMargins.ensureValuesAtLeast(top = topMargin, bottom = bottomMargin)

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultCartesianMarker.kt
@@ -175,6 +175,22 @@ public open class DefaultCartesianMarker(
           y = topPointY + (if (flip) 1 else -1) * tickSizeDp.pixels
           verticalPosition = if (flip) Position.Vertical.Bottom else Position.Vertical.Top
         }
+        LabelPosition.BelowPoint -> {
+          val bottomPointY =
+            targets.maxOf { target ->
+              when (target) {
+                is CandlestickCartesianLayerMarkerTarget -> target.lowCanvasY
+                is ColumnCartesianLayerMarkerTarget ->
+                  target.columns.maxOf(ColumnCartesianLayerMarkerTarget.Column::canvasY)
+                is LineCartesianLayerMarkerTarget ->
+                  target.points.maxOf(LineCartesianLayerMarkerTarget.Point::canvasY)
+                else -> error("Unexpected `CartesianMarker.Target` implementation.")
+              }
+            }
+          tickPosition = MarkerCorneredShape.TickPosition.Top
+          y = bottomPointY + tickSizeDp.pixels
+          verticalPosition = Position.Vertical.Bottom
+        }
       }
       markerCorneredShape?.tickPosition = tickPosition
 
@@ -217,7 +233,8 @@ public open class DefaultCartesianMarker(
         LabelPosition.Top,
         LabelPosition.AbovePoint ->
           layerMargins.ensureValuesAtLeast(top = label.getHeight(context) + tickSizeDp.pixels)
-        LabelPosition.Bottom ->
+        LabelPosition.Bottom,
+        LabelPosition.BelowPoint ->
           layerMargins.ensureValuesAtLeast(bottom = label.getHeight(context) + tickSizeDp.pixels)
         LabelPosition.AroundPoint -> Unit // Will be inside the chart
       }
@@ -262,6 +279,12 @@ public open class DefaultCartesianMarker(
      * [CartesianChart].
      */
     AbovePoint,
+
+    /**
+     * Positions the label below the bottommost marked point. Sufficient room is made at the bottom
+     * of the [CartesianChart].
+     */
+    BelowPoint,
   }
 
   /** Formats [CartesianMarker] values for display. */


### PR DESCRIPTION
Hello! We have a use case in our app where we want to show a point's label below the point itself. Currently there are only two options related with the point: `AbovePoint` and `AroundPoint`. Adding `BelowPoint` adds more configurability to how we want labels to be shown.

I also had an idea for another improvement when modifying the code: `AbovePoint` (and this new `BelowPoint`) could be configured to either the topmost or bottommost value, instead of "hardcoded" to one or the other. I haven't added this because it would need additional changes and might require some additional discussion on how to achieve this behaviour

Here's a demo of how it looks like:

https://github.com/user-attachments/assets/8c001352-789d-438a-a7e0-8d8c2139fa3e

