### PR TITLE
Consume Move pointer events in `TouchEvent`

### DIFF
--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
@@ -33,6 +33,7 @@ internal fun Modifier.pointerInput(
   scrollState: VicoScrollState,
   onPointerPositionChange: ((Point?) -> Unit)?,
   onZoom: ((Float, Offset) -> Unit)?,
+  consumeMoveEvents: Boolean,
 ) =
   scrollable(
       state = scrollState.scrollableState,
@@ -54,8 +55,11 @@ internal fun Modifier.pointerInput(
             event.type == PointerEventType.Press ->
               onPointerPositionChange(event.changes.first().position.toPoint())
             event.type == PointerEventType.Release -> onPointerPositionChange(null)
-            event.type == PointerEventType.Move && !scrollState.scrollEnabled ->
-              onPointerPositionChange(event.changes.first().position.toPoint())
+            event.type == PointerEventType.Move && !scrollState.scrollEnabled -> {
+              val changes = event.changes.first()
+              if (consumeMoveEvents) changes.consume()
+              onPointerPositionChange(changes.position.toPoint())
+            }
           }
         }
       }

--- a/vico/multiplatform/src/commonMain/kotlin/com/patrykandpatrick/vico/multiplatform/cartesian/CartesianChartHost.kt
+++ b/vico/multiplatform/src/commonMain/kotlin/com/patrykandpatrick/vico/multiplatform/cartesian/CartesianChartHost.kt
@@ -66,6 +66,7 @@ import kotlinx.coroutines.launch
  * @param animationSpec the [AnimationSpec] for difference animations.
  * @param animateIn whether to run an initial animation when the [CartesianChartHost] enters
  *   composition. The animation is skipped for previews.
+ * @param consumeMoveEvents whether move touch events will be consumed by the composable.
  * @param placeholder shown when no [CartesianChartModel] is available.
  */
 @Composable
@@ -77,6 +78,7 @@ public fun CartesianChartHost(
   zoomState: VicoZoomState = rememberDefaultVicoZoomState(scrollState.scrollEnabled),
   animationSpec: AnimationSpec<Float>? = defaultCartesianDiffAnimationSpec,
   animateIn: Boolean = true,
+  consumeMoveEvents: Boolean = false,
   placeholder: @Composable BoxScope.() -> Unit = {},
 ) {
   val mutableRanges = remember { MutableCartesianChartRanges() }
@@ -91,6 +93,7 @@ public fun CartesianChartHost(
         scrollState,
         zoomState,
         ranges,
+        consumeMoveEvents,
         previousModel,
         extraStore,
       )
@@ -119,6 +122,7 @@ public fun CartesianChartHost(
   modifier: Modifier = Modifier,
   scrollState: VicoScrollState = rememberVicoScrollState(),
   zoomState: VicoZoomState = rememberDefaultVicoZoomState(scrollState.scrollEnabled),
+  consumeMoveEvents: Boolean = false,
 ) {
   val ranges = remember { MutableCartesianChartRanges() }
   remember(chart, model) {
@@ -126,7 +130,14 @@ public fun CartesianChartHost(
     chart.updateRanges(ranges, model)
   }
   CartesianChartHostBox(modifier) {
-    CartesianChartHostImpl(chart, model, scrollState, zoomState, ranges.toImmutable())
+    CartesianChartHostImpl(
+      chart,
+      model,
+      scrollState,
+      zoomState,
+      ranges.toImmutable(),
+      consumeMoveEvents,
+    )
   }
 }
 
@@ -137,6 +148,7 @@ internal fun CartesianChartHostImpl(
   scrollState: VicoScrollState,
   zoomState: VicoZoomState,
   ranges: CartesianChartRanges,
+  consumeMoveEvents: Boolean,
   previousModel: CartesianChartModel? = null,
   extraStore: ExtraStore = ExtraStore.Empty,
 ) {
@@ -172,6 +184,7 @@ internal fun CartesianChartHostImpl(
       Modifier.fillMaxSize()
         .pointerInput(
           scrollState = scrollState,
+          consumeMoveEvents = consumeMoveEvents,
           onPointerPositionChange =
             remember(chart.marker == null) {
               if (chart.marker != null) pointerPosition.component2() else null

--- a/vico/multiplatform/src/commonMain/kotlin/com/patrykandpatrick/vico/multiplatform/cartesian/Modifier.kt
+++ b/vico/multiplatform/src/commonMain/kotlin/com/patrykandpatrick/vico/multiplatform/cartesian/Modifier.kt
@@ -37,6 +37,7 @@ internal fun Modifier.pointerInput(
   scrollState: VicoScrollState,
   onPointerPositionChange: ((Point?) -> Unit)?,
   onZoom: ((Float, Offset) -> Unit)?,
+  consumeMoveEvents: Boolean,
 ) =
   scrollable(
       state = scrollState.scrollableState,
@@ -54,12 +55,17 @@ internal fun Modifier.pointerInput(
                 1 - event.changes.first().scrollDelta.y * BASE_SCROLL_ZOOM_DELTA,
                 event.changes.first().position,
               )
+
             onPointerPositionChange == null -> continue
             event.type == PointerEventType.Press ->
               onPointerPositionChange(event.changes.first().position.toPoint())
+
             event.type == PointerEventType.Release -> onPointerPositionChange(null)
-            event.type == PointerEventType.Move && !scrollState.scrollEnabled ->
-              onPointerPositionChange(event.changes.first().position.toPoint())
+            event.type == PointerEventType.Move && !scrollState.scrollEnabled -> {
+              val changes = event.changes.first()
+              if (consumeMoveEvents) changes.consume()
+              onPointerPositionChange(changes.position.toPoint())
+            }
           }
         }
       }

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/gesture/MotionEventHandler.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/gesture/MotionEventHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ * Copyright 2025 by Patryk Goworowski and Patrick Michalik.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import kotlin.math.abs
 internal class MotionEventHandler(
   private val scroller: OverScroller,
   density: Float,
+  var consumeMoveEvents: Boolean,
   var scrollEnabled: Boolean = false,
   private val onTouchPoint: (Point?) -> Unit,
   private val requestInvalidate: () -> Unit,

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/theme/ThemeHandler.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/common/theme/ThemeHandler.kt
@@ -45,10 +45,15 @@ internal class ThemeHandler(private val context: Context, attrs: AttributeSet?) 
   var chart: CartesianChart? = null
     private set
 
+  var consumeMoveEvents: Boolean = false
+    private set
+
   init {
     context.obtainStyledAttributes(attrs, R.styleable.CartesianChartView).use { typedArray ->
       scrollEnabled = typedArray.getBoolean(R.styleable.CartesianChartView_scrollEnabled, true)
       zoomEnabled = typedArray.getBoolean(R.styleable.CartesianChartView_zoomEnabled, true)
+      consumeMoveEvents =
+        typedArray.getBoolean(R.styleable.CartesianChartView_consumeMoveEvents, false)
       typedArray
         .getNestedTypedArray(
           context,

--- a/vico/views/src/main/res/values/attrs.xml
+++ b/vico/views/src/main/res/values/attrs.xml
@@ -211,6 +211,9 @@
 
         <!-- Whether to enable zooming. -->
         <attr name="zoomEnabled" format="boolean" />
+
+        <!-- Whether to enable consumption of move events. -->
+        <attr name="consumeMoveEvents" format="boolean" />
     </declare-styleable>
 
     <declare-styleable name="CartesianChartStyle">


### PR DESCRIPTION
When a graph without horizontal scroll is in a horizontally scrollable component, such as a HorizontalPager, the events are not being consumed, resulting in a scroll when the user is interacting with the graph.
The `TouchEvent` should consume the move events so that the events are not processed by other scroll/touch handlers.

This change is only applied when scrolling is not enabled. When scrolling is enabled, the behaviour is the same.

Here's a before (old) and after (new) video with the change.

https://github.com/user-attachments/assets/030d09d6-e43f-4c7b-8e77-14dccee4d53b

https://github.com/user-attachments/assets/700e2d49-a603-4de5-80de-08a9c48c08e0

Please let me know if I missed anything, as this might be on purpose.

