### PR TITLE
Initial accessibility support in Compose

### DIFF
--- a/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/AITestScores.kt
+++ b/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/AITestScores.kt
@@ -47,13 +47,29 @@ import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
 import com.patrykandpatrick.vico.core.cartesian.decoration.HorizontalLine
 import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
+import com.patrykandpatrick.vico.core.cartesian.marker.ContentDescriptionProvider
+import com.patrykandpatrick.vico.core.cartesian.marker.LineCartesianLayerMarkerTarget
 import com.patrykandpatrick.vico.core.common.LegendItem
 import com.patrykandpatrick.vico.core.common.Position
 import com.patrykandpatrick.vico.core.common.data.ExtraStore
 import com.patrykandpatrick.vico.core.common.shape.CorneredShape
+import com.patrykandpatrick.vico.sample.compose.ContentDescriptionProvider
 import kotlinx.coroutines.runBlocking
 
 private val LegendLabelKey = ExtraStore.Key<Set<String>>()
+
+private val ContentDescriptionProvider = ContentDescriptionProvider { context, targets ->
+  val legendLabels = context.model.extraStore[LegendLabelKey].toList()
+  val target = targets.first() as LineCartesianLayerMarkerTarget
+  buildString {
+    append("Year: ${target.x.toInt()}.")
+    target.points.forEach { point ->
+      val seriesIndex = point.entry.seriesIndex
+      val label = legendLabels[seriesIndex]
+      append("$label: ${point.entry.y}.")
+    }
+  }
+}
 
 @Composable
 private fun rememberHorizontalLine(): HorizontalLine {
@@ -119,6 +135,7 @@ private fun JetpackComposeAITestScores(
           padding = insets(top = 16.dp),
         ),
       decorations = listOf(rememberHorizontalLine()),
+      contentDescriptionProvider = ContentDescriptionProvider,
     ),
     modelProducer,
     modifier.height(300.dp),

--- a/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/DailyDigitalMediaUse.kt
+++ b/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/DailyDigitalMediaUse.kt
@@ -45,18 +45,36 @@ import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.core.cartesian.data.columnSeries
 import com.patrykandpatrick.vico.core.cartesian.layer.ColumnCartesianLayer
+import com.patrykandpatrick.vico.core.cartesian.marker.ColumnCartesianLayerMarkerTarget
+import com.patrykandpatrick.vico.core.cartesian.marker.ContentDescriptionProvider
 import com.patrykandpatrick.vico.core.cartesian.marker.DefaultCartesianMarker
 import com.patrykandpatrick.vico.core.common.LegendItem
 import com.patrykandpatrick.vico.core.common.data.ExtraStore
 import com.patrykandpatrick.vico.core.common.shape.CorneredShape
+import com.patrykandpatrick.vico.sample.compose.ContentDescriptionProvider
 import java.text.DecimalFormat
 import kotlinx.coroutines.runBlocking
 
 private val LegendLabelKey = ExtraStore.Key<Set<String>>()
+
 private val YDecimalFormat = DecimalFormat("#.## h")
+
 private val StartAxisValueFormatter = CartesianValueFormatter.decimal(YDecimalFormat)
+
 private val StartAxisItemPlacer = VerticalAxis.ItemPlacer.step({ 0.5 })
+
 private val MarkerValueFormatter = DefaultCartesianMarker.ValueFormatter.default(YDecimalFormat)
+
+private val ContentDescriptionProvider = ContentDescriptionProvider { context, targets ->
+  val legendLabels = context.model.extraStore[LegendLabelKey]
+  val target = targets.first() as ColumnCartesianLayerMarkerTarget
+  buildString {
+    append("Year: ${target.x.toInt()}.")
+    target.columns.zip(legendLabels).forEach { (column, label) ->
+      append("$label: ${column.entry.y}.")
+    }
+  }
+}
 
 @Composable
 private fun JetpackComposeDailyDigitalMediaUse(
@@ -104,6 +122,7 @@ private fun JetpackComposeDailyDigitalMediaUse(
             },
             padding = insets(top = 16.dp),
           ),
+        contentDescriptionProvider = ContentDescriptionProvider,
       ),
     modelProducer = modelProducer,
     modifier = modifier.height(252.dp),

--- a/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/ElectricCarSales.kt
+++ b/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/ElectricCarSales.kt
@@ -40,15 +40,29 @@ import com.patrykandpatrick.vico.core.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
 import com.patrykandpatrick.vico.core.cartesian.layer.LineCartesianLayer
+import com.patrykandpatrick.vico.core.cartesian.marker.ContentDescriptionProvider
 import com.patrykandpatrick.vico.core.cartesian.marker.DefaultCartesianMarker
+import com.patrykandpatrick.vico.core.cartesian.marker.LineCartesianLayerMarkerTarget
 import com.patrykandpatrick.vico.core.common.shader.ShaderProvider
+import com.patrykandpatrick.vico.sample.compose.ContentDescriptionProvider
 import java.text.DecimalFormat
 import kotlinx.coroutines.runBlocking
 
 private val RangeProvider = CartesianLayerRangeProvider.fixed(maxY = 100.0)
+
 private val YDecimalFormat = DecimalFormat("#.##'%'")
+
 private val StartAxisValueFormatter = CartesianValueFormatter.decimal(YDecimalFormat)
+
 private val MarkerValueFormatter = DefaultCartesianMarker.ValueFormatter.default(YDecimalFormat)
+
+private val ContentDescriptionProvider = ContentDescriptionProvider { _, targets ->
+  val target = targets.first() as LineCartesianLayerMarkerTarget
+  buildString {
+    append("Year: ${target.x.toInt()}.")
+    target.points.forEach { point -> append("${point.entry.y}%.") }
+  }
+}
 
 @Composable
 private fun JetpackComposeElectricCarSales(
@@ -78,6 +92,7 @@ private fun JetpackComposeElectricCarSales(
       startAxis = VerticalAxis.rememberStart(valueFormatter = StartAxisValueFormatter),
       bottomAxis = HorizontalAxis.rememberBottom(),
       marker = rememberMarker(MarkerValueFormatter),
+      contentDescriptionProvider = ContentDescriptionProvider,
     ),
     modelProducer,
     modifier.height(220.dp),

--- a/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/RockMetalRatios.kt
+++ b/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/RockMetalRatios.kt
@@ -43,8 +43,10 @@ import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.core.cartesian.data.columnSeries
 import com.patrykandpatrick.vico.core.cartesian.layer.ColumnCartesianLayer
 import com.patrykandpatrick.vico.core.cartesian.marker.ColumnCartesianLayerMarkerTarget
+import com.patrykandpatrick.vico.core.cartesian.marker.ContentDescriptionProvider
 import com.patrykandpatrick.vico.core.cartesian.marker.DefaultCartesianMarker
 import com.patrykandpatrick.vico.core.common.data.ExtraStore
+import com.patrykandpatrick.vico.sample.compose.ContentDescriptionProvider
 import java.text.DecimalFormat
 import kotlinx.coroutines.runBlocking
 
@@ -73,6 +75,16 @@ private val MarkerValueFormatter =
       )
   }
 
+private val ContentDescriptionProvider = ContentDescriptionProvider { context, targets ->
+  val target = targets.first() as ColumnCartesianLayerMarkerTarget
+  buildString {
+    val metal = context.model.extraStore[BottomAxisLabelKey][target.x.toInt()]
+    append("$metal.")
+    val rockPerKgMetal = target.columns[0]
+    append("${rockPerKgMetal.entry.y}.")
+  }
+}
+
 @Composable
 private fun JetpackComposeRockMetalRatios(
   modelProducer: CartesianChartModelProducer,
@@ -94,6 +106,7 @@ private fun JetpackComposeRockMetalRatios(
           ),
         marker = rememberMarker(MarkerValueFormatter),
         layerPadding = { cartesianLayerPadding(scalableStart = 8.dp, scalableEnd = 8.dp) },
+        contentDescriptionProvider = ContentDescriptionProvider,
       ),
     modelProducer = modelProducer,
     modifier = modifier.height(220.dp),

--- a/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/TemperatureAnomalies.kt
+++ b/sample/compose/src/main/kotlin/com/patrykandpatrick/vico/sample/compose/TemperatureAnomalies.kt
@@ -41,10 +41,13 @@ import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.core.cartesian.data.ColumnCartesianLayerModel
 import com.patrykandpatrick.vico.core.cartesian.data.columnSeries
 import com.patrykandpatrick.vico.core.cartesian.layer.ColumnCartesianLayer
+import com.patrykandpatrick.vico.core.cartesian.marker.ColumnCartesianLayerMarkerTarget
+import com.patrykandpatrick.vico.core.cartesian.marker.ContentDescriptionProvider
 import com.patrykandpatrick.vico.core.cartesian.marker.DefaultCartesianMarker
 import com.patrykandpatrick.vico.core.common.component.LineComponent
 import com.patrykandpatrick.vico.core.common.data.ExtraStore
 import com.patrykandpatrick.vico.core.common.shape.CorneredShape
+import com.patrykandpatrick.vico.sample.compose.ContentDescriptionProvider
 import java.text.DecimalFormat
 import kotlin.math.abs
 import kotlin.math.ceil
@@ -67,6 +70,14 @@ private val YDecimalFormat = DecimalFormat("#.## °C;−#.## °C")
 private val StartAxisValueFormatter = CartesianValueFormatter.decimal(YDecimalFormat)
 
 private val MarkerValueFormatter = DefaultCartesianMarker.ValueFormatter.default(YDecimalFormat)
+
+private val ContentDescriptionProvider = ContentDescriptionProvider { _, targets ->
+  val target = targets.first() as ColumnCartesianLayerMarkerTarget
+  buildString {
+    append("Year: ${target.x.toInt()}.")
+    target.columns.forEach { column -> append("Anomaly: ${column.entry.y}°C.") }
+  }
+}
 
 private fun getColumnProvider(positive: LineComponent, negative: LineComponent) =
   object : ColumnCartesianLayer.ColumnProvider {
@@ -110,6 +121,7 @@ private fun JetpackComposeTemperatureAnomalies(
         startAxis = VerticalAxis.rememberStart(valueFormatter = StartAxisValueFormatter),
         bottomAxis = HorizontalAxis.rememberBottom(labelRotationDegrees = 45f),
         marker = rememberMarker(MarkerValueFormatter),
+        contentDescriptionProvider = ContentDescriptionProvider,
       ),
     modelProducer = modelProducer,
     modifier = modifier.height(238.dp),

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianChart.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianChart.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ * Copyright 2025 by Patryk Goworowski and Patrick Michalik.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.patrykandpatrick.vico.core.cartesian.layer.CartesianLayer
 import com.patrykandpatrick.vico.core.cartesian.layer.CartesianLayerPadding
 import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarker
 import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarkerVisibilityListener
+import com.patrykandpatrick.vico.core.cartesian.marker.ContentDescriptionProvider
 import com.patrykandpatrick.vico.core.common.Legend
 import com.patrykandpatrick.vico.core.common.ValueWrapper
 import com.patrykandpatrick.vico.core.common.data.ExtraStore
@@ -58,6 +59,7 @@ public fun rememberCartesianChart(
   decorations: List<Decoration> = emptyList(),
   persistentMarkers: (CartesianChart.PersistentMarkerScope.(ExtraStore) -> Unit)? = null,
   getXStep: ((CartesianChartModel) -> Double) = { it.getXDeltaGcd() },
+  contentDescriptionProvider: ContentDescriptionProvider = ContentDescriptionProvider.default,
 ): CartesianChart {
   val wrapper = remember { ValueWrapper<CartesianChart?>(null) }
   return remember(
@@ -74,6 +76,7 @@ public fun rememberCartesianChart(
     decorations,
     persistentMarkers,
     getXStep,
+    contentDescriptionProvider,
   ) {
     val cartesianChart =
       wrapper.value?.copy(
@@ -90,6 +93,7 @@ public fun rememberCartesianChart(
         decorations = decorations,
         persistentMarkers = persistentMarkers,
         getXStep = getXStep,
+        contentDescriptionProvider = contentDescriptionProvider,
       )
         ?: CartesianChart(
           *layers,
@@ -105,6 +109,7 @@ public fun rememberCartesianChart(
           decorations = decorations,
           persistentMarkers = persistentMarkers,
           getXStep = getXStep,
+          contentDescriptionProvider = contentDescriptionProvider,
         )
     wrapper.value = cartesianChart
     cartesianChart

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianDrawingContext.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/CartesianDrawingContext.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.cartesian
+
+import android.graphics.RectF
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.patrykandpatrick.vico.core.cartesian.CartesianDrawingContext
+import com.patrykandpatrick.vico.core.cartesian.CartesianMeasuringContext
+import com.patrykandpatrick.vico.core.cartesian.layer.CartesianLayerDimensions
+
+@Composable
+internal fun rememberCartesianDrawingContext(
+  measuringContext: CartesianMeasuringContext,
+  layerDimensions: CartesianLayerDimensions,
+  layerBounds: RectF,
+  scroll: Float,
+  zoom: Float,
+) =
+  remember(measuringContext, layerDimensions, layerBounds, scroll, zoom) {
+    CartesianDrawingContext(measuringContext, layerDimensions, layerBounds, scroll, zoom)
+  }

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/accessibility/AccessibilityHighlighter.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/cartesian/accessibility/AccessibilityHighlighter.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.cartesian.accessibility
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.patrykandpatrick.vico.core.cartesian.CartesianDrawingContext
+import com.patrykandpatrick.vico.core.cartesian.marker.CartesianMarker
+import com.patrykandpatrick.vico.core.cartesian.marker.ContentDescriptionProvider
+
+@Composable
+internal fun AccessibilityHighlighter(
+  targets: List<CartesianMarker.Target>,
+  context: CartesianDrawingContext,
+  contentDescriptionProvider: ContentDescriptionProvider,
+) {
+  val groupedTargets = targets.groupBy(CartesianMarker.Target::canvasX)
+
+  Box {
+    groupedTargets.forEach { (x, targetGroup) ->
+      Highlighter(
+        context.layerDimensions.xSpacing,
+        x,
+        context.layerBounds.top,
+        context.layerBounds.height(),
+        contentDescriptionProvider.getContentDescription(context, targetGroup),
+      )
+    }
+  }
+}
+
+@Composable
+private fun Highlighter(
+  xSpacing: Float,
+  canvasX: Float,
+  canvasTopY: Float,
+  height: Float,
+  contentDescription: String?,
+) {
+  val width = xSpacing.pxToDp()
+
+  Box(
+    Modifier.graphicsLayer {
+        translationX = canvasX - width.toPx() / 2
+        translationY = canvasTopY
+      }
+      .border(borderWidth, Color.Transparent)
+      .size(width, height.pxToDp())
+      .semantics {
+        if (contentDescription != null) {
+          this.contentDescription = contentDescription
+        }
+      }
+  )
+}
+
+@Composable private fun Float.pxToDp() = LocalDensity.current.run { toDp() }
+
+private val borderWidth = 2.dp

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/CartesianDrawingContext.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/CartesianDrawingContext.kt
@@ -66,16 +66,19 @@ internal fun CartesianDrawingContext.getVisibleXRange(): ClosedFloatingPointRang
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public fun CartesianDrawingContext(
   measuringContext: CartesianMeasuringContext,
-  canvas: Canvas,
   layerDimensions: CartesianLayerDimensions,
   layerBounds: RectF,
   scroll: Float,
   zoom: Float,
+  canvas: Canvas? = null,
 ): CartesianDrawingContext =
   object : CartesianDrawingContext, CartesianMeasuringContext by measuringContext {
     override val layerBounds: RectF = layerBounds
 
-    override var canvas: Canvas = canvas
+    private var internalCanvas: Canvas? = canvas
+
+    override val canvas: Canvas
+      get() = checkNotNull(internalCanvas)
 
     override val layerDimensions: CartesianLayerDimensions = layerDimensions
 
@@ -84,9 +87,9 @@ public fun CartesianDrawingContext(
     override val zoom: Float = zoom
 
     override fun withCanvas(canvas: Canvas, block: () -> Unit) {
-      val originalCanvas = this.canvas
-      this.canvas = canvas
+      val originalCanvas = internalCanvas
+      internalCanvas = canvas
       block()
-      this.canvas = originalCanvas
+      internalCanvas = originalCanvas
     }
   }

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/data/ColumnCartesianLayerModel.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/data/ColumnCartesianLayerModel.kt
@@ -135,15 +135,29 @@ public class ColumnCartesianLayerModel : CartesianLayerModel {
     return result
   }
 
-  /** Represents a column of height [y] at [x]. */
-  public class Entry internal constructor(override val x: Double, public val y: Double) :
+  /** Represents a column of height [y] at [x] in a specific series identified by [seriesIndex]. */
+  public class Entry
+  internal constructor(override val x: Double, public val y: Double, public val seriesIndex: Int) :
     CartesianLayerModel.Entry {
-    public constructor(x: Number, y: Number) : this(x.toDouble(), y.toDouble())
+    @Deprecated("Use the constructor with `seriesIndex` instead.")
+    public constructor(x: Number, y: Number) : this(x.toDouble(), y.toDouble(), -1)
+
+    public constructor(
+      x: Number,
+      y: Number,
+      seriesIndex: Int,
+    ) : this(x.toDouble(), y.toDouble(), seriesIndex)
 
     override fun equals(other: Any?): Boolean =
-      this === other || other is Entry && x == other.x && y == other.y
+      this === other ||
+        other is Entry && x == other.x && y == other.y && seriesIndex == other.seriesIndex
 
-    override fun hashCode(): Int = 31 * x.hashCode() + y.hashCode()
+    override fun hashCode(): Int {
+      var result = x.hashCode()
+      result = 31 * result + y.hashCode()
+      result = 31 * result + seriesIndex
+      return result
+    }
   }
 
   /**
@@ -169,7 +183,8 @@ public class ColumnCartesianLayerModel : CartesianLayerModel {
      * have the same size.
      */
     public fun series(x: Collection<Number>, y: Collection<Number>) {
-      series.add(x.zip(y, ColumnCartesianLayerModel::Entry))
+      val seriesIndex = series.size
+      series.add(x.zip(y) { x, y -> Entry(x, y, seriesIndex) })
     }
 
     /** Adds a series with the provided _y_ values ([y]), using their indices as the _x_ values. */

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/data/LineCartesianLayerModel.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/data/LineCartesianLayerModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ * Copyright 2025 by Patryk Goworowski and Patrick Michalik.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,15 +107,29 @@ public class LineCartesianLayerModel : CartesianLayerModel {
     return result
   }
 
-  /** Represents a line node at ([x], [y]). */
-  public class Entry internal constructor(override val x: Double, public val y: Double) :
+  /** Represents a line node at ([x], [y]) in the series at index [seriesIndex]. */
+  public class Entry
+  internal constructor(override val x: Double, public val y: Double, public val seriesIndex: Int) :
     CartesianLayerModel.Entry {
-    public constructor(x: Number, y: Number) : this(x.toDouble(), y.toDouble())
+    @Deprecated("Use the constructor with `seriesIndex` instead.")
+    public constructor(x: Number, y: Number) : this(x.toDouble(), y.toDouble(), -1)
+
+    public constructor(
+      x: Number,
+      y: Number,
+      seriesIndex: Int,
+    ) : this(x.toDouble(), y.toDouble(), seriesIndex)
 
     override fun equals(other: Any?): Boolean =
-      this === other || other is Entry && x == other.x && y == other.y
+      this === other ||
+        other is Entry && x == other.x && y == other.y && seriesIndex == other.seriesIndex
 
-    override fun hashCode(): Int = 31 * x.hashCode() + y.hashCode()
+    override fun hashCode(): Int {
+      var result = x.hashCode()
+      result = 31 * result + y.hashCode()
+      result = 31 * result + seriesIndex
+      return result
+    }
   }
 
   /**
@@ -141,7 +155,8 @@ public class LineCartesianLayerModel : CartesianLayerModel {
      * have the same size.
      */
     public fun series(x: Collection<Number>, y: Collection<Number>) {
-      series.add(x.zip(y, LineCartesianLayerModel::Entry))
+      val seriesIndex = series.size
+      series.add(x.zip(y) { x, y -> Entry(x, y, seriesIndex) })
     }
 
     /** Adds a series with the provided _y_ values ([y]), using their indices as the _x_ values. */

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/ContentDescriptionProvider.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/cartesian/marker/ContentDescriptionProvider.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.core.cartesian.marker
+
+import com.patrykandpatrick.vico.core.cartesian.CartesianChart
+import com.patrykandpatrick.vico.core.cartesian.CartesianDrawingContext
+
+/** Provides [CartesianChart] content descriptions. */
+public fun interface ContentDescriptionProvider {
+
+  /** Returns a content description for the given [CartesianMarker.Target]s. */
+  public fun getContentDescription(
+    context: CartesianDrawingContext,
+    targets: List<CartesianMarker.Target>,
+  ): String
+
+  /** Houses a [ContentDescriptionProvider] singleton. */
+  public companion object {
+    /** The default [ContentDescriptionProvider] implementation. */
+    public val default: ContentDescriptionProvider = DefaultContentDescriptionProvider
+  }
+}
+
+internal object DefaultContentDescriptionProvider : ContentDescriptionProvider {
+
+  override fun getContentDescription(
+    context: CartesianDrawingContext,
+    targets: List<CartesianMarker.Target>,
+  ) = buildString {
+    targets.forEachIndexed { index, target ->
+      appendTarget(target)
+      if (index < targets.lastIndex) {
+        append(" ")
+      }
+    }
+  }
+
+  private fun StringBuilder.appendTarget(target: CartesianMarker.Target) {
+    when (target) {
+      is CandlestickCartesianLayerMarkerTarget -> {
+        append("x: ${target.x}. ")
+        append("Opening: ${target.entry.opening}. ")
+        append("Closing: ${target.entry.closing}. ")
+        append("Low: ${target.entry.low}. ")
+        append("High: ${target.entry.high}.")
+      }
+
+      is ColumnCartesianLayerMarkerTarget -> {
+        append("x: ${target.x}. ")
+        target.columns.forEachIndexed { index, column ->
+          append("y: ${column.entry.y}.")
+          if (index < target.columns.lastIndex) {
+            append(" ")
+          }
+        }
+      }
+
+      is LineCartesianLayerMarkerTarget -> {
+        append("x: ${target.x}. ")
+        target.points.forEachIndexed { index, point ->
+          append("y: ${point.entry.y}.")
+          if (index < target.points.lastIndex) {
+            append(" ")
+          }
+        }
+      }
+
+      else -> throw IllegalArgumentException("Unexpected `CartesianMarker.Target` implementation.")
+    }
+  }
+}

--- a/vico/core/src/test/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultContentDescriptionProviderTest.kt
+++ b/vico/core/src/test/java/com/patrykandpatrick/vico/core/cartesian/marker/DefaultContentDescriptionProviderTest.kt
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2025 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.core.cartesian.marker
+
+import com.patrykandpatrick.vico.core.cartesian.CartesianDrawingContext
+import com.patrykandpatrick.vico.core.cartesian.data.CandlestickCartesianLayerModel
+import com.patrykandpatrick.vico.core.cartesian.data.ColumnCartesianLayerModel
+import com.patrykandpatrick.vico.core.cartesian.data.LineCartesianLayerModel
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class DefaultContentDescriptionProviderTest {
+
+  private val context = mockk<CartesianDrawingContext>()
+
+  private val provider = ContentDescriptionProvider.default
+
+  @Test
+  fun `should provide correct content description for single line target with single point`() {
+    val target =
+      createLineTarget(
+        x = 1.0,
+        points =
+          listOf(
+            LineCartesianLayerMarkerTarget.Point(
+              entry = LineCartesianLayerModel.Entry(1.0, 100.0, 0),
+              canvasY = 50f,
+              color = 0xFF0000,
+            )
+          ),
+      )
+
+    val result = provider.getContentDescription(context, listOf(target))
+
+    assertEquals("x: 1.0. y: 100.0.", result)
+  }
+
+  @Test
+  fun `should provide correct content description for single line target with multiple points`() {
+    val target =
+      createLineTarget(
+        x = 2.0,
+        points =
+          listOf(
+            LineCartesianLayerMarkerTarget.Point(
+              entry = LineCartesianLayerModel.Entry(2.0, 100.0, 0),
+              canvasY = 50f,
+              color = 0xFF0000,
+            ),
+            LineCartesianLayerMarkerTarget.Point(
+              entry = LineCartesianLayerModel.Entry(2.0, 200.0, 1),
+              canvasY = 75f,
+              color = 0x00FF00,
+            ),
+            LineCartesianLayerMarkerTarget.Point(
+              entry = LineCartesianLayerModel.Entry(2.0, 300.0, 2),
+              canvasY = 100f,
+              color = 0x0000FF,
+            ),
+          ),
+      )
+
+    val result = provider.getContentDescription(context, listOf(target))
+
+    assertEquals("x: 2.0. y: 100.0. y: 200.0. y: 300.0.", result)
+  }
+
+  @Test
+  fun `should provide correct content description for single column target with single column`() {
+    val target =
+      createColumnTarget(
+        x = 3.0,
+        columns =
+          listOf(
+            ColumnCartesianLayerMarkerTarget.Column(
+              entry = ColumnCartesianLayerModel.Entry(3.0, 150.0, 0),
+              canvasY = 60f,
+              color = 0xFF00FF,
+            )
+          ),
+      )
+
+    val result = provider.getContentDescription(context, listOf(target))
+
+    assertEquals("x: 3.0. y: 150.0.", result)
+  }
+
+  @Test
+  fun `should provide correct content description for single column target with multiple columns`() {
+    val target =
+      createColumnTarget(
+        x = 4.0,
+        columns =
+          listOf(
+            ColumnCartesianLayerMarkerTarget.Column(
+              entry = ColumnCartesianLayerModel.Entry(4.0, 50.0, 0),
+              canvasY = 25f,
+              color = 0xFF0000,
+            ),
+            ColumnCartesianLayerMarkerTarget.Column(
+              entry = ColumnCartesianLayerModel.Entry(4.0, 75.0, 1),
+              canvasY = 40f,
+              color = 0x00FF00,
+            ),
+          ),
+      )
+
+    val result = provider.getContentDescription(context, listOf(target))
+
+    assertEquals("x: 4.0. y: 50.0. y: 75.0.", result)
+  }
+
+  @Test
+  fun `should provide correct content description for candlestick cartesian layer marker target`() {
+    val target =
+      CandlestickCartesianLayerMarkerTarget(
+        x = 5.0,
+        canvasX = 100f,
+        entry =
+          CandlestickCartesianLayerModel.Entry(
+            x = 5.0,
+            opening = 100.0,
+            closing = 110.0,
+            low = 95.0,
+            high = 115.0,
+            absoluteChange = CandlestickCartesianLayerModel.Change.Bullish,
+            relativeChange = CandlestickCartesianLayerModel.Change.Bullish,
+          ),
+        openingCanvasY = 50f,
+        closingCanvasY = 55f,
+        lowCanvasY = 48f,
+        highCanvasY = 57f,
+        openingColor = 0xFF0000,
+        closingColor = 0x00FF00,
+        lowColor = 0x0000FF,
+        highColor = 0xFFFF00,
+      )
+
+    val result = provider.getContentDescription(context, listOf(target))
+
+    assertEquals("x: 5.0. Opening: 100.0. Closing: 110.0. Low: 95.0. High: 115.0.", result)
+  }
+
+  @Test
+  fun `should provide correct content description for multiple targets of different types`() {
+    val lineTarget =
+      createLineTarget(
+        x = 1.0,
+        points =
+          listOf(
+            LineCartesianLayerMarkerTarget.Point(
+              entry = LineCartesianLayerModel.Entry(1.0, 100.0, 0),
+              canvasY = 50f,
+              color = 0xFF0000,
+            )
+          ),
+      )
+
+    val columnTarget =
+      createColumnTarget(
+        x = 2.0,
+        columns =
+          listOf(
+            ColumnCartesianLayerMarkerTarget.Column(
+              entry = ColumnCartesianLayerModel.Entry(2.0, 150.0, 0),
+              canvasY = 60f,
+              color = 0xFF00FF,
+            )
+          ),
+      )
+
+    val candlestickTarget =
+      CandlestickCartesianLayerMarkerTarget(
+        x = 3.0,
+        canvasX = 100f,
+        entry =
+          CandlestickCartesianLayerModel.Entry(
+            x = 3.0,
+            opening = 200.0,
+            closing = 210.0,
+            low = 195.0,
+            high = 215.0,
+            absoluteChange = CandlestickCartesianLayerModel.Change.Bullish,
+            relativeChange = CandlestickCartesianLayerModel.Change.Bullish,
+          ),
+        openingCanvasY = 50f,
+        closingCanvasY = 55f,
+        lowCanvasY = 48f,
+        highCanvasY = 57f,
+        openingColor = 0xFF0000,
+        closingColor = 0x00FF00,
+        lowColor = 0x0000FF,
+        highColor = 0xFFFF00,
+      )
+
+    val result =
+      provider.getContentDescription(context, listOf(lineTarget, columnTarget, candlestickTarget))
+
+    assertEquals(
+      "x: 1.0. y: 100.0. x: 2.0. y: 150.0. x: 3.0. Opening: 200.0. Closing: 210.0. Low: 195.0. High: 215.0.",
+      result,
+    )
+  }
+
+  @Test
+  fun `should provide correct content description for multiple line targets`() {
+    val target1 =
+      createLineTarget(
+        x = 1.0,
+        points =
+          listOf(
+            LineCartesianLayerMarkerTarget.Point(
+              entry = LineCartesianLayerModel.Entry(1.0, 100.0, 0),
+              canvasY = 50f,
+              color = 0xFF0000,
+            ),
+            LineCartesianLayerMarkerTarget.Point(
+              entry = LineCartesianLayerModel.Entry(1.0, 200.0, 1),
+              canvasY = 75f,
+              color = 0x00FF00,
+            ),
+          ),
+      )
+
+    val target2 =
+      createLineTarget(
+        x = 2.0,
+        points =
+          listOf(
+            LineCartesianLayerMarkerTarget.Point(
+              entry = LineCartesianLayerModel.Entry(2.0, 300.0, 0),
+              canvasY = 100f,
+              color = 0x0000FF,
+            )
+          ),
+      )
+
+    val result = provider.getContentDescription(context, listOf(target1, target2))
+
+    assertEquals("x: 1.0. y: 100.0. y: 200.0. x: 2.0. y: 300.0.", result)
+  }
+
+  @Test
+  fun `should provide correct content description for multiple column targets`() {
+    val target1 =
+      createColumnTarget(
+        x = 1.0,
+        columns =
+          listOf(
+            ColumnCartesianLayerMarkerTarget.Column(
+              entry = ColumnCartesianLayerModel.Entry(1.0, 50.0, 0),
+              canvasY = 25f,
+              color = 0xFF0000,
+            )
+          ),
+      )
+
+    val target2 =
+      createColumnTarget(
+        x = 2.0,
+        columns =
+          listOf(
+            ColumnCartesianLayerMarkerTarget.Column(
+              entry = ColumnCartesianLayerModel.Entry(2.0, 75.0, 0),
+              canvasY = 40f,
+              color = 0x00FF00,
+            ),
+            ColumnCartesianLayerMarkerTarget.Column(
+              entry = ColumnCartesianLayerModel.Entry(2.0, 100.0, 1),
+              canvasY = 50f,
+              color = 0x0000FF,
+            ),
+          ),
+      )
+
+    val result = provider.getContentDescription(context, listOf(target1, target2))
+
+    assertEquals("x: 1.0. y: 50.0. x: 2.0. y: 75.0. y: 100.0.", result)
+  }
+
+  @Test
+  fun `should return empty string for empty targets list`() {
+    val result = provider.getContentDescription(context, emptyList())
+
+    assertEquals("", result)
+  }
+
+  @Test
+  fun `should throw IllegalArgumentException for unexpected target implementation`() {
+    val unexpectedTarget =
+      object : CartesianMarker.Target {
+        override val x: Double = 1.0
+        override val canvasX: Float = 50f
+      }
+
+    assertThrows<IllegalArgumentException> {
+      provider.getContentDescription(context, listOf(unexpectedTarget))
+    }
+  }
+
+  private fun createLineTarget(
+    x: Double,
+    canvasX: Float = 50f,
+    points: List<LineCartesianLayerMarkerTarget.Point>,
+  ): LineCartesianLayerMarkerTarget {
+    return MutableLineCartesianLayerMarkerTarget(
+      x = x,
+      canvasX = canvasX,
+      points = points.toMutableList(),
+    )
+  }
+
+  private fun createColumnTarget(
+    x: Double,
+    canvasX: Float = 50f,
+    columns: List<ColumnCartesianLayerMarkerTarget.Column>,
+  ): ColumnCartesianLayerMarkerTarget {
+    return MutableColumnCartesianLayerMarkerTarget(
+      x = x,
+      canvasX = canvasX,
+      columns = columns.toMutableList(),
+    )
+  }
+}

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
@@ -352,11 +352,11 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
       val drawingContext =
         CartesianDrawingContext(
           measuringContext,
-          canvas,
           layerDimensions,
           chart.layerBounds,
           scrollHandler.value,
           zoomHandler.value,
+          canvas,
         )
 
       chart.draw(drawingContext)


### PR DESCRIPTION
## Description

This PR adds minimal accessibility support to Vico charts. It introduces a `contentDescription` parameter, allowing meaningful descriptions to be passed for data points. These descriptions will be read by TalkBack, improving the chart experience for screen reader users.

Note: this doesn’t make the entire chart accessible, full support should be introduced in separate PRs. If preferred, I can retarget this PR to a feature branch instead of master, but it should already provide some accessibility improvements on its own.

How to Review This PR:
The suggested way to review this PR is by going commit-by-commit. I’ve left comments in places where I saw potential for improvement or ran into limitations. I hope that your deep knowledge of the library can help improve or fix some of these areas.

## PR Scope
- Chart data points can now include a content description that will be announced by TalkBack, making them more accessible to screen reader users.

## Out of scope
- Chart legend accessibility
- Chart markers accessibility
- Chart decorations accessibility
- Automatically scrolling to chart elements that are out of screen bounds as accessibility focus moves.
This should be handled in a future PR, as it requires implementing `BringIntoViewRequester` together with `BringIntoViewResponder` and connecting it to `VicoScrollState`. The main challenge here is the lack of a reliable callback that tells us when an element is focused by accessibility services unfortunately, `.onFocusChanged { }` doesn’t get triggered during accessibility navigation. To keep this PR smaller, I’m leaving this out for now.

## Demos

In each demo, TalkBack is enabled and I’m using left/right swipe gestures (default accessibility navigation method), to move between elements with semantics. You’ll notice that chart data points with `contentDescription` are now announced.

Previously, the entire chart was skipped, and accessibility focus jumped directly to previous/next arrows.

Please watch the demos with sound on to hear the TalkBack announcements in action.

| Chart Type         | Accessibility Demo |
|--------------------|--------------------|
| Column Chart       | <video src="https://github.com/user-attachments/assets/d84a3999-bced-4b35-a5d9-2bf6e959790d" width="450" controls></video> |
| Line Chart         | <video src="https://github.com/user-attachments/assets/d7634244-3147-4a51-b493-c64d3c40bee6" width="450" controls></video> |
| Candlestick Chart  | <video src="https://github.com/user-attachments/assets/63b1f2ec-8150-44a6-8f10-95f880828b5c" width="450" controls></video> |

## Known issues

This section describes known issues currently affecting chart accessibility. These can be addressed in this PR if you consider them blockers, or in future PRs. In most cases, I ran into some issues while trying to fix them, which is why they’re currently left as-is.

### Combo charts

In combo charts, some data points may prevent others from being announced. For example, in the demo video, you can see that for x = 8 and x = 9, the column data points are not announced. This happens because the line points are positioned higher than the columns, and the accessibility system assumes the columns are not visible (and thus not focusable).

https://github.com/user-attachments/assets/fb516788-ca4f-4922-9e2c-70b005f2d546

### Negative values

The highlighter for negative values starts from the bottom instead of the top. It might look a bit weird visually, but it’s not a problem for TalkBack.

https://github.com/user-attachments/assets/63d3a5ab-4255-4fe3-81a9-5396553077a8

### Clickable charts with markers

When charts contain markers (making them clickable), the accessibility focus might jump to the touched position. This only happens when the user swipes back and forth through accessibility elements while swiping on the chart itself. If the user swipes just under or over the chart, focus moves correctly between data points.. This can be seen i.e on the Electric car sales chart.

## Resources
https://eevis.codes/blog/2023-07-24/more-accessible-graphs-with-jetpack-compose-part-1-adding-content/