### PR TITLE
Add snap scrolling feature to align scroll position to grid windows

### DIFF
--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
@@ -85,19 +85,79 @@ class VicoScrollStateTest {
       job.cancelAndJoin()
     }
 
-  private fun createScrollState(): VicoScrollState =
+  @Test
+  fun `When xSnapStep is set, then snap delta accounts for layer start padding`() = runBlocking {
+    val sut =
+      createScrollState(
+        xSnapStep = 2.0,
+        layerDimensions =
+          MutableCartesianLayerDimensions(
+            xSpacing = 10f,
+            scalableStartPadding = 7f,
+            unscalableStartPadding = 3f,
+          ),
+      )
+
+    sut.scroll(Scroll.Absolute.pixels(27f))
+
+    assertEquals(3f, sut.getSnapDelta())
+  }
+
+  @Test
+  fun `When xSnapStep is set and scroll is at start, then snap delta is null`() = runBlocking {
+    val sut =
+      createScrollState(
+        xSnapStep = 2.0,
+        layerDimensions =
+          MutableCartesianLayerDimensions(
+            xSpacing = 10f,
+            scalableStartPadding = 7f,
+            unscalableStartPadding = 3f,
+          ),
+      )
+
+    assertEquals(0f, sut.value)
+    assertEquals(null, sut.getSnapDelta())
+  }
+
+  @Test
+  fun `When xSnapStep is set and target is projected, then snap delta uses projected target`() =
+    runBlocking {
+      val sut =
+        createScrollState(
+          xSnapStep = 2.0,
+          layerDimensions =
+            MutableCartesianLayerDimensions(
+              xSpacing = 10f,
+              scalableStartPadding = 7f,
+              unscalableStartPadding = 3f,
+            ),
+        )
+
+      sut.scroll(Scroll.Absolute.pixels(12f))
+
+      assertEquals(38f, sut.getSnapDelta(targetValue = 49f))
+    }
+
+  private fun createScrollState(
+    xSnapStep: Double? = null,
+    layerDimensions: MutableCartesianLayerDimensions =
+      MutableCartesianLayerDimensions(xSpacing = 20f),
+  ): VicoScrollState =
     VicoScrollState(
         scrollEnabled = true,
         initialScroll = Scroll.Absolute.Start,
         autoScroll = Scroll.Absolute.Start,
         autoScrollCondition = AutoScrollCondition.Never,
         autoScrollAnimationSpec = tween(),
+        xSnapStep = xSnapStep,
+        snapAnimationSpec = tween(),
       )
       .also {
         it.update(
           context = context,
           bounds = Rect(0f, 0f, 100f, 100f),
-          layerDimensions = MutableCartesianLayerDimensions(xSpacing = 20f),
+          layerDimensions = layerDimensions,
         )
         it.maxValue = 100f
       }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
@@ -16,13 +16,20 @@
 
 package com.patrykandpatrick.vico.compose.cartesian
 
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.FlingBehavior
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollScope
+import androidx.compose.foundation.gestures.ScrollableDefaults
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
@@ -51,12 +58,22 @@ internal fun Modifier.pointerInput(
   onZoom: ((Float, Offset) -> Unit)?,
   consumeMoveEvents: Boolean,
   longPressEnabled: Boolean,
-) =
-  scrollable(
+): Modifier {
+  val defaultFlingBehavior = ScrollableDefaults.flingBehavior()
+  val flingBehavior =
+    remember(scrollState, defaultFlingBehavior) {
+      if (scrollState.snapScrollX != null) {
+        SnapFlingBehavior(scrollState, defaultFlingBehavior)
+      } else {
+        defaultFlingBehavior
+      }
+    }
+  return scrollable(
       state = scrollState.scrollableState,
       orientation = Orientation.Horizontal,
       enabled = scrollState.scrollEnabled,
       reverseDirection = true,
+      flingBehavior = flingBehavior,
     )
     .pointerInput(onZoom, onInteraction) {
       awaitPointerEventScope {
@@ -132,6 +149,7 @@ internal fun Modifier.pointerInput(
       }
     )
     .extraPointerInput(scrollState)
+}
 
 private suspend fun PointerInputScope.detectTapGestures(
   onTap: (Offset) -> Boolean,
@@ -167,3 +185,20 @@ private fun PointerInputChange?.isTap(firstDown: PointerInputChange): Boolean {
 }
 
 private fun Offset.fits(size: IntSize) = x >= 0f && x <= size.width && y >= 0f && y <= size.height
+
+internal class SnapFlingBehavior(
+  private val scrollState: VicoScrollState,
+  private val delegate: FlingBehavior,
+  private val snapAnimationSpec: AnimationSpec<Float> = spring(),
+) : FlingBehavior {
+  override suspend fun ScrollScope.performFling(initialVelocity: Float): Float {
+    val remaining = with(delegate) { performFling(initialVelocity) }
+    val snapDelta = scrollState.getSnapDelta() ?: return remaining
+    var previousValue = 0f
+    animate(0f, snapDelta, animationSpec = snapAnimationSpec) { value, _ ->
+      scrollBy(value - previousValue)
+      previousValue = value
+    }
+    return 0f
+  }
+}

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.kt
@@ -16,9 +16,10 @@
 
 package com.patrykandpatrick.vico.compose.cartesian
 
-import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.DecayAnimationSpec
 import androidx.compose.animation.core.animate
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.calculateTargetValue
+import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.gestures.FlingBehavior
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.ScrollScope
@@ -60,10 +61,11 @@ internal fun Modifier.pointerInput(
   longPressEnabled: Boolean,
 ): Modifier {
   val defaultFlingBehavior = ScrollableDefaults.flingBehavior()
+  val decayAnimationSpec = rememberSplineBasedDecay<Float>()
   val flingBehavior =
-    remember(scrollState, defaultFlingBehavior) {
-      if (scrollState.snapScrollX != null) {
-        SnapFlingBehavior(scrollState, defaultFlingBehavior)
+    remember(scrollState, defaultFlingBehavior, decayAnimationSpec) {
+      if (scrollState.xSnapStep != null) {
+        SnapFlingBehavior(scrollState, decayAnimationSpec)
       } else {
         defaultFlingBehavior
       }
@@ -188,14 +190,18 @@ private fun Offset.fits(size: IntSize) = x >= 0f && x <= size.width && y >= 0f &
 
 internal class SnapFlingBehavior(
   private val scrollState: VicoScrollState,
-  private val delegate: FlingBehavior,
-  private val snapAnimationSpec: AnimationSpec<Float> = spring(),
+  private val decayAnimationSpec: DecayAnimationSpec<Float>,
 ) : FlingBehavior {
   override suspend fun ScrollScope.performFling(initialVelocity: Float): Float {
-    val remaining = with(delegate) { performFling(initialVelocity) }
-    val snapDelta = scrollState.getSnapDelta() ?: return remaining
+    val targetValue = decayAnimationSpec.calculateTargetValue(scrollState.value, initialVelocity)
+    val snapDelta = scrollState.getSnapDelta(targetValue) ?: return 0f
     var previousValue = 0f
-    animate(0f, snapDelta, animationSpec = snapAnimationSpec) { value, _ ->
+    animate(
+      initialValue = 0f,
+      targetValue = snapDelta,
+      initialVelocity = initialVelocity,
+      animationSpec = scrollState.snapAnimationSpec,
+    ) { value, _ ->
       scrollBy(value - previousValue)
       previousValue = value
     }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/SnapScroll.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/SnapScroll.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.cartesian
+
+import com.patrykandpatrick.vico.compose.common.rangeWith
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+internal fun getSnapDelta(
+  value: Float,
+  maxValue: Float,
+  xSnapStep: Double?,
+  xStep: Double,
+  xSpacing: Float,
+  startPadding: Float,
+  targetValue: Float = value,
+): Float? {
+  val snapTarget =
+    getSnapTarget(
+      maxValue = maxValue,
+      xSnapStep = xSnapStep,
+      xStep = xStep,
+      xSpacing = xSpacing,
+      startPadding = startPadding,
+      targetValue = targetValue,
+    ) ?: return null
+  val delta = snapTarget - value
+  return if (delta == 0f) null else delta
+}
+
+internal fun getSnapTarget(
+  maxValue: Float,
+  xSnapStep: Double?,
+  xStep: Double,
+  xSpacing: Float,
+  startPadding: Float,
+  targetValue: Float,
+): Float? {
+  xSnapStep ?: return null
+  val windowPx = (xSnapStep / xStep).toFloat() * xSpacing
+  if (windowPx <= 0f) return null
+  val coercedTargetValue = targetValue.coerceIn(0f.rangeWith(maxValue))
+  val closestStepTarget =
+    startPadding + ((coercedTargetValue - startPadding) / windowPx).roundToInt() * windowPx
+  return listOf(0f, closestStepTarget, maxValue)
+    .filter { it in 0f.rangeWith(maxValue) }
+    .minBy { abs(it - coercedTargetValue) }
+}

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -122,8 +122,8 @@ public class VicoScrollState {
    * @param autoScroll represents the scroll value or delta for automatic scrolling.
    * @param autoScrollCondition defines when an automatic scroll should occur.
    * @param autoScrollAnimationSpec the [AnimationSpec] for automatic scrolling.
-   * @param snapScrollX if not null, the scroll will snap to multiples of this _x_-axis window
-   *   width after the user stops scrolling.
+   * @param snapScrollX if not null, the scroll will snap to multiples of this _x_-axis window width
+   *   after the user stops scrolling.
    */
   public constructor(
     scrollEnabled: Boolean,
@@ -222,11 +222,13 @@ public class VicoScrollState {
     val snapScrollX = snapScrollX ?: return null
     val context = this.context ?: return null
     val layerDimensions = this.layerDimensions ?: return null
-    val windowPx =
-      (snapScrollX / context.ranges.xStep).toFloat() * layerDimensions.xSpacing
+    val windowPx = (snapScrollX / context.ranges.xStep).toFloat() * layerDimensions.xSpacing
     if (windowPx <= 0f) return null
+    val startPadding = layerDimensions.startPadding
     val snapTarget =
-      ((value / windowPx).roundToInt() * windowPx).coerceIn(0f.rangeWith(maxValue))
+      (startPadding + ((value - startPadding) / windowPx).roundToInt() * windowPx).coerceIn(
+        0f.rangeWith(maxValue)
+      )
     val delta = snapTarget - value
     return if (delta == 0f) null else delta
   }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.geometry.Rect
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.CartesianLayerDimensions
 import com.patrykandpatrick.vico.compose.common.rangeWith
+import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 
@@ -56,6 +57,7 @@ public class VicoScrollState {
   private var layerDimensions: CartesianLayerDimensions? = null
   private var bounds: Rect? = null
   internal var scrollEnabled by mutableStateOf(true)
+  internal val snapScrollX: Double?
   internal val consumedXDeltas = MutableSharedFlow<Float>(extraBufferCapacity = 1)
   internal val unconsumedXDeltas = MutableSharedFlow<Float>(extraBufferCapacity = 1)
 
@@ -97,6 +99,7 @@ public class VicoScrollState {
     autoScroll: Scroll,
     autoScrollCondition: AutoScrollCondition,
     autoScrollAnimationSpec: AnimationSpec<Float>,
+    snapScrollX: Double?,
     value: Float,
     initialScrollHandled: Boolean,
   ) {
@@ -105,6 +108,7 @@ public class VicoScrollState {
     this.autoScroll = autoScroll
     this.autoScrollCondition = autoScrollCondition
     this.autoScrollAnimationSpec = autoScrollAnimationSpec
+    this.snapScrollX = snapScrollX
     _value = mutableFloatStateOf(value)
     this.initialScrollHandled = initialScrollHandled
   }
@@ -118,6 +122,8 @@ public class VicoScrollState {
    * @param autoScroll represents the scroll value or delta for automatic scrolling.
    * @param autoScrollCondition defines when an automatic scroll should occur.
    * @param autoScrollAnimationSpec the [AnimationSpec] for automatic scrolling.
+   * @param snapScrollX if not null, the scroll will snap to multiples of this _x_-axis window
+   *   width after the user stops scrolling.
    */
   public constructor(
     scrollEnabled: Boolean,
@@ -125,12 +131,14 @@ public class VicoScrollState {
     autoScroll: Scroll,
     autoScrollCondition: AutoScrollCondition,
     autoScrollAnimationSpec: AnimationSpec<Float>,
+    snapScrollX: Double? = null,
   ) : this(
     scrollEnabled = scrollEnabled,
     initialScroll = initialScroll,
     autoScroll = autoScroll,
     autoScrollCondition = autoScrollCondition,
     autoScrollAnimationSpec = autoScrollAnimationSpec,
+    snapScrollX = snapScrollX,
     value = 0f,
     initialScrollHandled = false,
   )
@@ -210,6 +218,24 @@ public class VicoScrollState {
     }
   }
 
+  internal fun getSnapDelta(): Float? {
+    val snapScrollX = snapScrollX ?: return null
+    val context = this.context ?: return null
+    val layerDimensions = this.layerDimensions ?: return null
+    val windowPx =
+      (snapScrollX / context.ranges.xStep).toFloat() * layerDimensions.xSpacing
+    if (windowPx <= 0f) return null
+    val snapTarget =
+      ((value / windowPx).roundToInt() * windowPx).coerceIn(0f.rangeWith(maxValue))
+    val delta = snapTarget - value
+    return if (delta == 0f) null else delta
+  }
+
+  internal suspend fun performSnap(animationSpec: AnimationSpec<Float> = spring()) {
+    val delta = getSnapDelta() ?: return
+    scrollableState.animateScrollBy(delta, animationSpec)
+  }
+
   internal companion object {
     fun Saver(
       scrollEnabled: Boolean,
@@ -217,6 +243,7 @@ public class VicoScrollState {
       autoScroll: Scroll,
       autoScrollCondition: AutoScrollCondition,
       autoScrollAnimationSpec: AnimationSpec<Float>,
+      snapScrollX: Double?,
     ) =
       Saver<VicoScrollState, Pair<Float, Boolean>>(
         save = { it.value to it.initialScrollHandled },
@@ -227,6 +254,7 @@ public class VicoScrollState {
             autoScroll,
             autoScrollCondition,
             autoScrollAnimationSpec,
+            snapScrollX,
             value,
             initialScrollHandled,
           )
@@ -235,7 +263,12 @@ public class VicoScrollState {
   }
 }
 
-/** Creates and remembers a [VicoScrollState] instance. */
+/**
+ * Creates and remembers a [VicoScrollState] instance.
+ *
+ * @param snapScrollX if not null, the scroll will snap to multiples of this _x_-axis window width
+ *   after the user stops scrolling.
+ */
 @Composable
 public fun rememberVicoScrollState(
   scrollEnabled: Boolean = true,
@@ -243,6 +276,7 @@ public fun rememberVicoScrollState(
   autoScroll: Scroll = initialScroll,
   autoScrollCondition: AutoScrollCondition = AutoScrollCondition.Never,
   autoScrollAnimationSpec: AnimationSpec<Float> = spring(),
+  snapScrollX: Double? = null,
 ): VicoScrollState {
   val state =
     rememberSaveable(
@@ -250,14 +284,22 @@ public fun rememberVicoScrollState(
       autoScroll,
       autoScrollCondition,
       autoScrollAnimationSpec,
+      snapScrollX,
       saver =
-        remember(scrollEnabled, initialScroll, autoScrollCondition, autoScrollAnimationSpec) {
+        remember(
+          scrollEnabled,
+          initialScroll,
+          autoScrollCondition,
+          autoScrollAnimationSpec,
+          snapScrollX,
+        ) {
           VicoScrollState.Saver(
             scrollEnabled,
             initialScroll,
             autoScroll,
             autoScrollCondition,
             autoScrollAnimationSpec,
+            snapScrollX,
           )
         },
     ) {
@@ -267,6 +309,7 @@ public fun rememberVicoScrollState(
         autoScroll,
         autoScrollCondition,
         autoScrollAnimationSpec,
+        snapScrollX,
       )
     }
   SideEffect { state.scrollEnabled = scrollEnabled }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.geometry.Rect
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.CartesianLayerDimensions
 import com.patrykandpatrick.vico.compose.common.rangeWith
-import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 
@@ -50,6 +49,7 @@ public class VicoScrollState {
   private val autoScroll: Scroll
   private val autoScrollCondition: AutoScrollCondition
   private val autoScrollAnimationSpec: AnimationSpec<Float>
+  internal val snapAnimationSpec: AnimationSpec<Float>
   private val _value: MutableFloatState
   private val _maxValue = mutableFloatStateOf(0f)
   private var initialScrollHandled: Boolean
@@ -57,7 +57,7 @@ public class VicoScrollState {
   private var layerDimensions: CartesianLayerDimensions? = null
   private var bounds: Rect? = null
   internal var scrollEnabled by mutableStateOf(true)
-  internal val snapScrollX: Double?
+  internal val xSnapStep: Double?
   internal val consumedXDeltas = MutableSharedFlow<Float>(extraBufferCapacity = 1)
   internal val unconsumedXDeltas = MutableSharedFlow<Float>(extraBufferCapacity = 1)
 
@@ -99,7 +99,8 @@ public class VicoScrollState {
     autoScroll: Scroll,
     autoScrollCondition: AutoScrollCondition,
     autoScrollAnimationSpec: AnimationSpec<Float>,
-    snapScrollX: Double?,
+    xSnapStep: Double?,
+    snapAnimationSpec: AnimationSpec<Float>,
     value: Float,
     initialScrollHandled: Boolean,
   ) {
@@ -108,7 +109,8 @@ public class VicoScrollState {
     this.autoScroll = autoScroll
     this.autoScrollCondition = autoScrollCondition
     this.autoScrollAnimationSpec = autoScrollAnimationSpec
-    this.snapScrollX = snapScrollX
+    this.xSnapStep = xSnapStep
+    this.snapAnimationSpec = snapAnimationSpec
     _value = mutableFloatStateOf(value)
     this.initialScrollHandled = initialScrollHandled
   }
@@ -122,8 +124,9 @@ public class VicoScrollState {
    * @param autoScroll represents the scroll value or delta for automatic scrolling.
    * @param autoScrollCondition defines when an automatic scroll should occur.
    * @param autoScrollAnimationSpec the [AnimationSpec] for automatic scrolling.
-   * @param snapScrollX if not null, the scroll will snap to multiples of this _x_-axis window width
-   *   after the user stops scrolling.
+   * @param xSnapStep if not null, the scroll will snap to multiples of this _x_-axis step after the
+   *   user stops scrolling.
+   * @param snapAnimationSpec the [AnimationSpec] for snap scrolling.
    */
   public constructor(
     scrollEnabled: Boolean,
@@ -131,14 +134,16 @@ public class VicoScrollState {
     autoScroll: Scroll,
     autoScrollCondition: AutoScrollCondition,
     autoScrollAnimationSpec: AnimationSpec<Float>,
-    snapScrollX: Double? = null,
+    xSnapStep: Double?,
+    snapAnimationSpec: AnimationSpec<Float>,
   ) : this(
     scrollEnabled = scrollEnabled,
     initialScroll = initialScroll,
     autoScroll = autoScroll,
     autoScrollCondition = autoScrollCondition,
     autoScrollAnimationSpec = autoScrollAnimationSpec,
-    snapScrollX = snapScrollX,
+    xSnapStep = xSnapStep,
+    snapAnimationSpec = snapAnimationSpec,
     value = 0f,
     initialScrollHandled = false,
   )
@@ -218,26 +223,40 @@ public class VicoScrollState {
     }
   }
 
-  internal fun getSnapDelta(): Float? {
-    val snapScrollX = snapScrollX ?: return null
+  internal fun getSnapDelta(targetValue: Float = value): Float? {
     val context = this.context ?: return null
     val layerDimensions = this.layerDimensions ?: return null
-    val windowPx = (snapScrollX / context.ranges.xStep).toFloat() * layerDimensions.xSpacing
-    if (windowPx <= 0f) return null
-    val startPadding = layerDimensions.startPadding
-    val snapTarget =
-      (startPadding + ((value - startPadding) / windowPx).roundToInt() * windowPx).coerceIn(
-        0f.rangeWith(maxValue)
-      )
-    val delta = snapTarget - value
-    return if (delta == 0f) null else delta
+    return getSnapDelta(
+      value = value,
+      maxValue = maxValue,
+      xSnapStep = xSnapStep,
+      xStep = context.ranges.xStep,
+      xSpacing = layerDimensions.xSpacing,
+      startPadding = layerDimensions.startPadding,
+      targetValue = targetValue,
+    )
   }
 
-  internal suspend fun performSnap(animationSpec: AnimationSpec<Float> = spring()) {
-    val delta = getSnapDelta() ?: return
+  internal suspend fun performSnap(
+    targetValue: Float = value,
+    initialVelocity: Float = 0f,
+    animationSpec: AnimationSpec<Float> = snapAnimationSpec,
+  ) {
+    val delta = getSnapDelta(targetValue) ?: return
     scrollableState.stopScroll(MutatePriority.PreventUserInput)
     isScrollInProgress.first { !it }
-    scrollableState.animateScrollBy(delta, animationSpec)
+    scrollableState.scroll(MutatePriority.PreventUserInput) {
+      var previousValue = 0f
+      animate(
+        initialValue = 0f,
+        targetValue = delta,
+        initialVelocity = initialVelocity,
+        animationSpec = animationSpec,
+      ) { value, _ ->
+        scrollBy(value - previousValue)
+        previousValue = value
+      }
+    }
   }
 
   internal companion object {
@@ -247,7 +266,8 @@ public class VicoScrollState {
       autoScroll: Scroll,
       autoScrollCondition: AutoScrollCondition,
       autoScrollAnimationSpec: AnimationSpec<Float>,
-      snapScrollX: Double?,
+      xSnapStep: Double?,
+      snapAnimationSpec: AnimationSpec<Float>,
     ) =
       Saver<VicoScrollState, Pair<Float, Boolean>>(
         save = { it.value to it.initialScrollHandled },
@@ -258,7 +278,8 @@ public class VicoScrollState {
             autoScroll,
             autoScrollCondition,
             autoScrollAnimationSpec,
-            snapScrollX,
+            xSnapStep,
+            snapAnimationSpec,
             value,
             initialScrollHandled,
           )
@@ -270,8 +291,9 @@ public class VicoScrollState {
 /**
  * Creates and remembers a [VicoScrollState] instance.
  *
- * @param snapScrollX if not null, the scroll will snap to multiples of this _x_-axis window width
- *   after the user stops scrolling.
+ * @param xSnapStep if not null, the scroll will snap to multiples of this _x_-axis step after the
+ *   user stops scrolling.
+ * @param snapAnimationSpec the [AnimationSpec] for snap scrolling.
  */
 @Composable
 public fun rememberVicoScrollState(
@@ -280,7 +302,8 @@ public fun rememberVicoScrollState(
   autoScroll: Scroll = initialScroll,
   autoScrollCondition: AutoScrollCondition = AutoScrollCondition.Never,
   autoScrollAnimationSpec: AnimationSpec<Float> = spring(),
-  snapScrollX: Double? = null,
+  xSnapStep: Double? = null,
+  snapAnimationSpec: AnimationSpec<Float> = spring(),
 ): VicoScrollState {
   val state =
     rememberSaveable(
@@ -288,14 +311,16 @@ public fun rememberVicoScrollState(
       autoScroll,
       autoScrollCondition,
       autoScrollAnimationSpec,
-      snapScrollX,
+      xSnapStep,
+      snapAnimationSpec,
       saver =
         remember(
           scrollEnabled,
           initialScroll,
           autoScrollCondition,
           autoScrollAnimationSpec,
-          snapScrollX,
+          xSnapStep,
+          snapAnimationSpec,
         ) {
           VicoScrollState.Saver(
             scrollEnabled,
@@ -303,7 +328,8 @@ public fun rememberVicoScrollState(
             autoScroll,
             autoScrollCondition,
             autoScrollAnimationSpec,
-            snapScrollX,
+            xSnapStep,
+            snapAnimationSpec,
           )
         },
     ) {
@@ -313,7 +339,8 @@ public fun rememberVicoScrollState(
         autoScroll,
         autoScrollCondition,
         autoScrollAnimationSpec,
-        snapScrollX,
+        xSnapStep,
+        snapAnimationSpec,
       )
     }
   SideEffect { state.scrollEnabled = scrollEnabled }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -233,6 +233,8 @@ public class VicoScrollState {
 
   internal suspend fun performSnap(animationSpec: AnimationSpec<Float> = spring()) {
     val delta = getSnapDelta() ?: return
+    scrollableState.stopScroll(MutatePriority.PreventUserInput)
+    isScrollInProgress.first { !it }
     scrollableState.animateScrollBy(delta, animationSpec)
   }
 

--- a/vico/compose/src/desktopMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.desktop.kt
+++ b/vico/compose/src/desktopMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.desktop.kt
@@ -50,6 +50,7 @@ internal actual fun Modifier.extraPointerInput(scrollState: VicoScrollState): Mo
           AnimationState(scrollState.value, velocity).animateDecay(animationSpec) {
             launch { scrollState.scroll(Scroll.Absolute.pixels(value)) }
           }
+          scrollState.performSnap()
         }
     },
     reverseDirection = true,

--- a/vico/compose/src/desktopMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.desktop.kt
+++ b/vico/compose/src/desktopMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.desktop.kt
@@ -18,6 +18,7 @@ package com.patrykandpatrick.vico.compose.cartesian
 
 import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.animateDecay
+import androidx.compose.animation.core.calculateTargetValue
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
@@ -47,10 +48,16 @@ internal actual fun Modifier.extraPointerInput(scrollState: VicoScrollState): Mo
       scrollJob?.cancel()
       scrollJob =
         coroutineScope.launch {
-          AnimationState(scrollState.value, velocity).animateDecay(animationSpec) {
-            launch { scrollState.scroll(Scroll.Absolute.pixels(value)) }
+          if (scrollState.xSnapStep == null) {
+            AnimationState(scrollState.value, velocity).animateDecay(animationSpec) {
+              launch { scrollState.scroll(Scroll.Absolute.pixels(value)) }
+            }
+          } else {
+            scrollState.performSnap(
+              targetValue = animationSpec.calculateTargetValue(scrollState.value, velocity),
+              initialVelocity = velocity,
+            )
           }
-          scrollState.performSnap()
         }
     },
     reverseDirection = true,

--- a/vico/compose/src/webMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.web.kt
+++ b/vico/compose/src/webMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.web.kt
@@ -50,6 +50,7 @@ internal actual fun Modifier.extraPointerInput(scrollState: VicoScrollState): Mo
           AnimationState(scrollState.value, velocity).animateDecay(animationSpec) {
             launch { scrollState.scroll(Scroll.Absolute.pixels(value)) }
           }
+          scrollState.performSnap()
         }
     },
     reverseDirection = true,

--- a/vico/compose/src/webMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.web.kt
+++ b/vico/compose/src/webMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/Modifier.web.kt
@@ -18,6 +18,7 @@ package com.patrykandpatrick.vico.compose.cartesian
 
 import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.animateDecay
+import androidx.compose.animation.core.calculateTargetValue
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
@@ -47,10 +48,16 @@ internal actual fun Modifier.extraPointerInput(scrollState: VicoScrollState): Mo
       scrollJob?.cancel()
       scrollJob =
         coroutineScope.launch {
-          AnimationState(scrollState.value, velocity).animateDecay(animationSpec) {
-            launch { scrollState.scroll(Scroll.Absolute.pixels(value)) }
+          if (scrollState.xSnapStep == null) {
+            AnimationState(scrollState.value, velocity).animateDecay(animationSpec) {
+              launch { scrollState.scroll(Scroll.Absolute.pixels(value)) }
+            }
+          } else {
+            scrollState.performSnap(
+              targetValue = animationSpec.calculateTargetValue(scrollState.value, velocity),
+              initialVelocity = velocity,
+            )
           }
-          scrollState.performSnap()
         }
     },
     reverseDirection = true,

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
@@ -103,6 +103,8 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 
   private var scrollDirectionResolved = false
 
+  private var wasUserScrolling = false
+
   private val layerDimensions = MutableCartesianLayerDimensions()
 
   private var previousLayerPaddingHashCode: Int? = null
@@ -306,6 +308,13 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   override fun onTouchEvent(event: MotionEvent): Boolean {
     val superHandled = super.onTouchEvent(event)
     if (!isEnabled || !event.shouldAccept()) return superHandled
+    if (
+      scrollHandler.scrollEnabled &&
+        event.actionMasked == MotionEvent.ACTION_MOVE &&
+        scrollHandler.snapScrollX != null
+    ) {
+      wasUserScrolling = true
+    }
     val scaleHandled =
       if (zoomHandler.zoomEnabled && event.pointerCount > 1 && scrollHandler.scrollEnabled) {
         scaleGestureDetector.onTouchEvent(event)
@@ -419,11 +428,15 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 
       var viewportChange = false
       motionEventHandler.scrollEnabled = scrollHandler.scrollEnabled
-      if (scroller.computeScrollOffset()) {
+      val isScrollerRunning = scroller.computeScrollOffset()
+      if (isScrollerRunning) {
         val delta = scroller.currX.toFloat()
         scrollHandler.scroll(Scroll.Absolute.pixels(delta))
         viewportChange = true
         postInvalidateOnAnimation()
+      } else if (wasUserScrolling) {
+        wasUserScrolling = false
+        scrollHandler.performSnap()
       }
 
       zoomHandler.update(measuringContext, layerDimensions, chart.layerBounds, scrollHandler.value)

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
@@ -104,6 +104,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   private var scrollDirectionResolved = false
 
   private var wasUserScrolling = false
+  private var isUserScrolling = false
 
   private val layerDimensions = MutableCartesianLayerDimensions()
 
@@ -140,7 +141,8 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
       density = resources.displayMetrics.density,
       onInteraction = ::handleInteraction,
       requestInvalidate = ::invalidate,
-      onUserScroll = { wasUserScrolling = true },
+      onUserScroll = { if (scrollHandler.xSnapStep != null) wasUserScrolling = true },
+      onSnapScroll = { wasUserScrolling = false },
     )
 
   /** The [CartesianChart] displayed by this [View]. */
@@ -318,6 +320,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
     val touchHandled = motionEventHandler.handleMotionEvent(event, scrollHandler)
     val gestureHandled = gestureDetector.onTouchEvent(event)
     val hasMarker = chart?.marker != null
+    if (wasUserScrolling) isUserScrolling = true
     when {
       chart?.markerController?.consumeMoveEvents == true &&
         !scrollHandler.scrollEnabled &&
@@ -334,6 +337,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 
       event.isUpOrCancel() -> {
         scrollDirectionResolved = false
+        isUserScrolling = false
       }
     }
 
@@ -421,6 +425,13 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
       if (chart.layerBounds.isEmpty) return@withChartAndModel
 
       var viewportChange = false
+      zoomHandler.update(measuringContext, layerDimensions, chart.layerBounds, scrollHandler.value)
+      scrollHandler.update(measuringContext, chart.layerBounds, layerDimensions)
+      zoomHandler.consumePendingScroll { scroll ->
+        scrollHandler.scroll(scroll)
+        viewportChange = true
+      }
+
       motionEventHandler.scrollEnabled = scrollHandler.scrollEnabled
       val isScrollerRunning = scroller.computeScrollOffset()
       if (isScrollerRunning) {
@@ -428,16 +439,9 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         scrollHandler.scroll(Scroll.Absolute.pixels(delta))
         viewportChange = true
         postInvalidateOnAnimation()
-      } else if (wasUserScrolling) {
+      } else if (wasUserScrolling && !isUserScrolling) {
         wasUserScrolling = false
         scrollHandler.performSnap()
-      }
-
-      zoomHandler.update(measuringContext, layerDimensions, chart.layerBounds, scrollHandler.value)
-      scrollHandler.update(measuringContext, chart.layerBounds, layerDimensions)
-      zoomHandler.consumePendingScroll { scroll ->
-        scrollHandler.scroll(scroll)
-        viewportChange = true
       }
 
       val drawingContext =

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/CartesianChartView.kt
@@ -140,6 +140,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
       density = resources.displayMetrics.density,
       onInteraction = ::handleInteraction,
       requestInvalidate = ::invalidate,
+      onUserScroll = { wasUserScrolling = true },
     )
 
   /** The [CartesianChart] displayed by this [View]. */
@@ -308,13 +309,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   override fun onTouchEvent(event: MotionEvent): Boolean {
     val superHandled = super.onTouchEvent(event)
     if (!isEnabled || !event.shouldAccept()) return superHandled
-    if (
-      scrollHandler.scrollEnabled &&
-        event.actionMasked == MotionEvent.ACTION_MOVE &&
-        scrollHandler.snapScrollX != null
-    ) {
-      wasUserScrolling = true
-    }
     val scaleHandled =
       if (zoomHandler.zoomEnabled && event.pointerCount > 1 && scrollHandler.scrollEnabled) {
         scaleGestureDetector.onTouchEvent(event)

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/ScrollHandler.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/ScrollHandler.kt
@@ -218,11 +218,13 @@ public class ScrollHandler(
     val snapScrollX = snapScrollX ?: return
     val context = this.context ?: return
     val layerDimensions = this.layerDimensions ?: return
-    val windowPx =
-      (snapScrollX / context.ranges.xStep).toFloat() * layerDimensions.xSpacing
+    val windowPx = (snapScrollX / context.ranges.xStep).toFloat() * layerDimensions.xSpacing
     if (windowPx <= 0f) return
+    val startPadding = layerDimensions.startPadding
     val snapTarget =
-      ((value / windowPx).roundToInt() * windowPx).coerceIn(0f.rangeWith(maxValue))
+      (startPadding + ((value - startPadding) / windowPx).roundToInt() * windowPx).coerceIn(
+        0f.rangeWith(maxValue)
+      )
     val delta = snapTarget - value
     if (delta == 0f) return
     animateScrollBy(delta, duration, interpolator)

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/ScrollHandler.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/ScrollHandler.kt
@@ -27,6 +27,7 @@ import com.patrykandpatrick.vico.views.cartesian.data.CartesianChartModel
 import com.patrykandpatrick.vico.views.cartesian.layer.CartesianLayerDimensions
 import com.patrykandpatrick.vico.views.common.Animation
 import com.patrykandpatrick.vico.views.common.rangeWith
+import kotlin.math.roundToInt
 
 /**
  * Houses information on a [CartesianChart]’s scroll value. Allows for scroll customization and
@@ -38,6 +39,8 @@ import com.patrykandpatrick.vico.views.common.rangeWith
  * @property autoScrollCondition defines when an automatic scroll should be performed.
  * @property autoScrollInterpolator the [TimeInterpolator] for automatic scrolling.
  * @property autoScrollDuration the animation duration for automatic scrolling.
+ * @property snapScrollX if not null, the scroll will snap to multiples of this _x_-axis window
+ *   width after the user stops scrolling.
  */
 public class ScrollHandler(
   public var scrollEnabled: Boolean = true,
@@ -46,6 +49,7 @@ public class ScrollHandler(
   private val autoScrollCondition: AutoScrollCondition = AutoScrollCondition.Never,
   private val autoScrollInterpolator: TimeInterpolator = AccelerateDecelerateInterpolator(),
   private val autoScrollDuration: Long = Animation.DIFF_DURATION.toLong(),
+  public val snapScrollX: Double? = null,
 ) {
   private val scrollListeners = mutableSetOf<Listener>()
   private var initialScrollHandled = false
@@ -205,6 +209,23 @@ public class ScrollHandler(
         interpolator,
       )
     }
+  }
+
+  internal fun performSnap(
+    duration: Long = Animation.DIFF_DURATION.toLong(),
+    interpolator: TimeInterpolator = AccelerateDecelerateInterpolator(),
+  ) {
+    val snapScrollX = snapScrollX ?: return
+    val context = this.context ?: return
+    val layerDimensions = this.layerDimensions ?: return
+    val windowPx =
+      (snapScrollX / context.ranges.xStep).toFloat() * layerDimensions.xSpacing
+    if (windowPx <= 0f) return
+    val snapTarget =
+      ((value / windowPx).roundToInt() * windowPx).coerceIn(0f.rangeWith(maxValue))
+    val delta = snapTarget - value
+    if (delta == 0f) return
+    animateScrollBy(delta, duration, interpolator)
   }
 
   /** Adds the provided [Listener]. */

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/ScrollHandler.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/ScrollHandler.kt
@@ -24,9 +24,11 @@ import android.graphics.RectF
 import android.os.Bundle
 import android.view.animation.AccelerateDecelerateInterpolator
 import com.patrykandpatrick.vico.views.cartesian.data.CartesianChartModel
+import com.patrykandpatrick.vico.views.cartesian.getSnapTarget as calculateSnapTarget
 import com.patrykandpatrick.vico.views.cartesian.layer.CartesianLayerDimensions
 import com.patrykandpatrick.vico.views.common.Animation
 import com.patrykandpatrick.vico.views.common.rangeWith
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
@@ -39,8 +41,13 @@ import kotlin.math.roundToInt
  * @property autoScrollCondition defines when an automatic scroll should be performed.
  * @property autoScrollInterpolator the [TimeInterpolator] for automatic scrolling.
  * @property autoScrollDuration the animation duration for automatic scrolling.
- * @property snapScrollX if not null, the scroll will snap to multiples of this _x_-axis window
- *   width after the user stops scrolling.
+ * @property xSnapStep if not null, the scroll will snap to multiples of this _x_-axis step after
+ *   the user stops scrolling.
+ * @property snapInterpolator the [TimeInterpolator] for snap scrolling when no fling velocity is
+ *   available. Snaps after a fling use the fling’s projected destination and platform scrolling
+ *   behavior instead.
+ * @property snapDuration the snap scroll animation duration when no fling velocity is available,
+ *   and the maximum snap scroll duration when a fling velocity is available.
  */
 public class ScrollHandler(
   public var scrollEnabled: Boolean = true,
@@ -49,7 +56,9 @@ public class ScrollHandler(
   private val autoScrollCondition: AutoScrollCondition = AutoScrollCondition.Never,
   private val autoScrollInterpolator: TimeInterpolator = AccelerateDecelerateInterpolator(),
   private val autoScrollDuration: Long = Animation.DIFF_DURATION.toLong(),
-  public val snapScrollX: Double? = null,
+  public val xSnapStep: Double? = null,
+  private val snapInterpolator: TimeInterpolator = AccelerateDecelerateInterpolator(),
+  private val snapDuration: Long = Animation.ANIMATED_SCROLL_DURATION.toLong(),
 ) {
   private val scrollListeners = mutableSetOf<Listener>()
   private var initialScrollHandled = false
@@ -145,6 +154,10 @@ public class ScrollHandler(
     postInvalidateOnAnimation = null
   }
 
+  internal fun stopAnimation() {
+    animator.cancel()
+  }
+
   private fun scrollBy(delta: Float): Float {
     val oldValue = value
     value += delta
@@ -211,23 +224,43 @@ public class ScrollHandler(
     }
   }
 
-  internal fun performSnap(
-    duration: Long = Animation.DIFF_DURATION.toLong(),
-    interpolator: TimeInterpolator = AccelerateDecelerateInterpolator(),
-  ) {
-    val snapScrollX = snapScrollX ?: return
-    val context = this.context ?: return
-    val layerDimensions = this.layerDimensions ?: return
-    val windowPx = (snapScrollX / context.ranges.xStep).toFloat() * layerDimensions.xSpacing
-    if (windowPx <= 0f) return
-    val startPadding = layerDimensions.startPadding
-    val snapTarget =
-      (startPadding + ((value - startPadding) / windowPx).roundToInt() * windowPx).coerceIn(
-        0f.rangeWith(maxValue)
-      )
-    val delta = snapTarget - value
-    if (delta == 0f) return
-    animateScrollBy(delta, duration, interpolator)
+  internal fun performSnap() {
+    val delta = getSnapDelta() ?: return
+    animateScrollBy(delta, snapDuration, snapInterpolator)
+  }
+
+  internal fun getSnapTarget(targetValue: Float): Float? {
+    val context = this.context ?: return null
+    val layerDimensions = this.layerDimensions ?: return null
+    return calculateSnapTarget(
+      maxValue = maxValue,
+      xSnapStep = xSnapStep,
+      xStep = context.ranges.xStep,
+      xSpacing = layerDimensions.xSpacing,
+      startPadding = layerDimensions.startPadding,
+      targetValue = targetValue,
+    )
+  }
+
+  internal fun getSnapScrollDuration(distance: Int, velocity: Int, velocityUnits: Int): Int {
+    val maxDuration = snapDuration.coerceAtLeast(MIN_SNAP_SCROLL_DURATION.toLong()).toInt()
+    val velocityPxPerSecond = abs(velocity) * VELOCITY_UNITS_PER_SECOND / velocityUnits.toFloat()
+    return (abs(distance).toFloat() / velocityPxPerSecond * VELOCITY_UNITS_PER_SECOND)
+      .roundToInt()
+      .coerceIn(MIN_SNAP_SCROLL_DURATION, maxDuration)
+  }
+
+  private fun getSnapDelta(): Float? {
+    val context = this.context ?: return null
+    val layerDimensions = this.layerDimensions ?: return null
+    return getSnapDelta(
+      value = value,
+      maxValue = maxValue,
+      xSnapStep = xSnapStep,
+      xStep = context.ranges.xStep,
+      xSpacing = layerDimensions.xSpacing,
+      startPadding = layerDimensions.startPadding,
+    )
   }
 
   /** Adds the provided [Listener]. */
@@ -251,6 +284,8 @@ public class ScrollHandler(
   }
 
   private companion object {
+    const val MIN_SNAP_SCROLL_DURATION = 50
+    const val VELOCITY_UNITS_PER_SECOND = 1_000
     const val VALUE_KEY = "value"
     const val INITIAL_SCROLL_HANDLED_KEY = "initialScrollHandled"
   }

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/SnapScroll.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/SnapScroll.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.views.cartesian
+
+import com.patrykandpatrick.vico.views.common.rangeWith
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+internal fun getSnapDelta(
+  value: Float,
+  maxValue: Float,
+  xSnapStep: Double?,
+  xStep: Double,
+  xSpacing: Float,
+  startPadding: Float,
+  targetValue: Float = value,
+): Float? {
+  val snapTarget =
+    getSnapTarget(
+      maxValue = maxValue,
+      xSnapStep = xSnapStep,
+      xStep = xStep,
+      xSpacing = xSpacing,
+      startPadding = startPadding,
+      targetValue = targetValue,
+    ) ?: return null
+  val delta = snapTarget - value
+  return if (delta == 0f) null else delta
+}
+
+internal fun getSnapTarget(
+  maxValue: Float,
+  xSnapStep: Double?,
+  xStep: Double,
+  xSpacing: Float,
+  startPadding: Float,
+  targetValue: Float,
+): Float? {
+  xSnapStep ?: return null
+  val windowPx = (xSnapStep / xStep).toFloat() * xSpacing
+  if (windowPx <= 0f) return null
+  val coercedTargetValue = targetValue.coerceIn(0f.rangeWith(maxValue))
+  val closestStepTarget =
+    startPadding + ((coercedTargetValue - startPadding) / windowPx).roundToInt() * windowPx
+  return listOf(0f, closestStepTarget, maxValue)
+    .filter { it in 0f.rangeWith(maxValue) }
+    .minBy { abs(it - coercedTargetValue) }
+}

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/common/gesture/MotionEventHandler.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/common/gesture/MotionEventHandler.kt
@@ -34,6 +34,7 @@ internal class MotionEventHandler(
   var scrollEnabled: Boolean = false,
   private val onInteraction: (Interaction) -> Unit,
   private val requestInvalidate: () -> Unit,
+  private val onUserScroll: () -> Unit = {},
   internal val chartBounds: RectF = RectF(),
 ) {
   private val velocityUnits = (VELOCITY_PIXELS * density).toInt()
@@ -69,8 +70,11 @@ internal class MotionEventHandler(
           val shouldPerformScroll = totalDragAmount > dragThreshold
           if (shouldPerformScroll && !ignoreEvent) {
             velocityTracker.get().addMovement(motionEvent)
-            if (scrollHandler.scroll(Scroll.Relative.pixels(lastX - currentX)) == 0f) {
+            val consumed = scrollHandler.scroll(Scroll.Relative.pixels(lastX - currentX))
+            if (consumed == 0f) {
               onInteraction(Interaction.Move(motionEvent.point))
+            } else {
+              onUserScroll()
             }
             requestInvalidate()
             initialX = -dragThreshold

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/common/gesture/MotionEventHandler.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/common/gesture/MotionEventHandler.kt
@@ -27,6 +27,7 @@ import com.patrykandpatrick.vico.views.cartesian.marker.Interaction
 import com.patrykandpatrick.vico.views.common.fling
 import com.patrykandpatrick.vico.views.common.point
 import kotlin.math.abs
+import kotlin.math.roundToInt
 
 internal class MotionEventHandler(
   private val scroller: OverScroller,
@@ -35,6 +36,7 @@ internal class MotionEventHandler(
   private val onInteraction: (Interaction) -> Unit,
   private val requestInvalidate: () -> Unit,
   private val onUserScroll: () -> Unit = {},
+  private val onSnapScroll: () -> Unit = {},
   internal val chartBounds: RectF = RectF(),
 ) {
   private val velocityUnits = (VELOCITY_PIXELS * density).toInt()
@@ -54,6 +56,7 @@ internal class MotionEventHandler(
     return when (motionEvent.action and MotionEvent.ACTION_MASK) {
       MotionEvent.ACTION_DOWN -> {
         scroller.abortAnimation()
+        scrollHandler.stopAnimation()
         initialX = motionEvent.x
         onInteraction(Interaction.Press(motionEvent.point))
         lastX = initialX
@@ -112,11 +115,31 @@ internal class MotionEventHandler(
         velocityTracker.get().apply {
           computeCurrentVelocity(velocityUnits)
           val currentX = scrollHandler.value.toInt()
+          val velocityX = -xVelocity.toInt()
           scroller.fling(
             startX = currentX,
-            velocityX = -xVelocity.toInt(),
+            velocityX = velocityX,
             maxScrollX = scrollHandler.maxValue.toInt(),
           )
+          scrollHandler
+            .getSnapTarget(scroller.finalX.toFloat())
+            ?.roundToInt()
+            ?.takeIf { velocityX != 0 && it != currentX }
+            ?.let { snapTarget ->
+              scroller.abortAnimation()
+              scroller.startScroll(
+                currentX,
+                0,
+                snapTarget - currentX,
+                0,
+                scrollHandler.getSnapScrollDuration(
+                  distance = snapTarget - currentX,
+                  velocity = velocityX,
+                  velocityUnits = velocityUnits,
+                ),
+              )
+              onSnapScroll()
+            }
           requestInvalidate()
         }
         velocityTracker.clear()

--- a/vico/views/src/test/kotlin/com/patrykandpatrick/vico/views/cartesian/ScrollHandlerTest.kt
+++ b/vico/views/src/test/kotlin/com/patrykandpatrick/vico/views/cartesian/ScrollHandlerTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.views.cartesian
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ScrollHandlerTest {
+  @Test
+  fun `When xSnapStep is set, then snap delta accounts for layer start padding`() =
+    assertEquals(
+      3f,
+      getSnapDelta(
+        value = 27f,
+        maxValue = 100f,
+        xSnapStep = 2.0,
+        xStep = 1.0,
+        xSpacing = 10f,
+        startPadding = 10f,
+      ),
+    )
+
+  @Test
+  fun `When xSnapStep is set and scroll is at start, then snap delta is null`() {
+    assertEquals(
+      null,
+      getSnapDelta(
+        value = 0f,
+        maxValue = 100f,
+        xSnapStep = 2.0,
+        xStep = 1.0,
+        xSpacing = 10f,
+        startPadding = 10f,
+      ),
+    )
+  }
+
+  @Test
+  fun `When xSnapStep is set and target is projected, then snap delta uses projected target`() {
+    assertEquals(
+      38f,
+      getSnapDelta(
+        value = 12f,
+        maxValue = 100f,
+        xSnapStep = 2.0,
+        xStep = 1.0,
+        xSpacing = 10f,
+        startPadding = 10f,
+        targetValue = 49f,
+      ),
+    )
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds snap scrolling, which aligns the scroll position to multiples of a configurable _x_-axis step after the user stops scrolling. This is useful for charts where the viewport should settle on meaningful data boundaries. The feature is opt-in and applies to both stacks: Compose Multiplatform (all platforms) and Android Views.

## Public API

- **Compose:** `rememberVicoScrollState` and `VicoScrollState` gain an `xSnapStep: Double?` parameter (the snap step in _x_-axis units; `null` disables snapping) and a `snapAnimationSpec: AnimationSpec<Float>` parameter for the snap animation.
- **Views:** `ScrollHandler` gains an `xSnapStep: Double?` property plus `snapInterpolator` and `snapDuration` parameters. `snapDuration` is the animation duration when no fling velocity is available, and the maximum duration when a fling velocity is available.

## Snap calculation

Snap targets are computed by shared, side-effect-free helpers in the new `SnapScroll.kt` files (one per stack), keeping the Compose and Views logic in sync:

- `getSnapTarget(...)` converts `xSnapStep` to a pixel window using `xStep` and `xSpacing`, accounts for the layer's start padding so the grid aligns to data positions, and returns the nearest of the start (`0`), the closest snap step, and `maxValue` — all coerced into the valid scroll range.
- `getSnapDelta(...)` returns the delta from the current value to the snap target, or `null` when there's nothing to snap to (e.g. already aligned, or snapping disabled).

Both helpers accept a projected `targetValue` so snapping can target a fling's destination rather than the scroll position at release.

## Compose implementation

- A `SnapFlingBehavior` wraps the fling: it projects the decay's target value, then animates to the snap delta using `snapAnimationSpec`. It's installed via `Modifier.pointerInput` only when `xSnapStep` is set; otherwise the default fling behavior is used.
- `VicoScrollState` exposes internal `getSnapDelta()` and a `performSnap()` suspend function that stops any in-flight scroll, waits for it to settle, and animates to the snap target within a single mutator session.
- On Desktop and Web, `Modifier.extraPointerInput` calls `performSnap()` with the decay's projected target after a drag-driven fling instead of running the plain decay loop.

## Views implementation

- `MotionEventHandler` gains `onUserScroll`/`onSnapScroll` callbacks, fires `onUserScroll` only when a drag actually moves the scroll (so taps and sub-threshold movement don't trigger a snap), and, on fling, replaces the `OverScroller` fling with a `startScroll` to the snap target when one exists — using a velocity-derived duration from `ScrollHandler.getSnapScrollDuration`. It also stops any running snap animation on `ACTION_DOWN`.
- `ScrollHandler` gains `performSnap()` (used when no fling velocity is available), `getSnapTarget`, `getSnapScrollDuration`, and `stopAnimation`.
- `CartesianChartView` tracks user-scroll state (`wasUserScrolling`/`isUserScrolling`) and, in the animation loop, triggers `performSnap()` once the user has stopped scrolling and the scroller is no longer running.

## Tests

- `VicoScrollStateTest` (Compose) and `ScrollHandlerTest` (Views) cover start-padding alignment, the no-op-at-start case, and projected-target snapping.
