### PR TITLE
Fix: use dataLabelValueFormatter in rememberLine()

### DIFF
--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/LineCartesianLayer.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/LineCartesianLayer.kt
@@ -1100,7 +1100,7 @@ public fun LineCartesianLayer.Companion.rememberLine(
     interpolator,
     dataLabel,
     dataLabelPosition,
-    dataLabelRotationDegrees,
+    dataLabelValueFormatter,
     dataLabelRotationDegrees,
   ) {
     Line(


### PR DESCRIPTION
dataLabelRotationDegrees is passed to remember twice and dataLabelValueFormatter is not passed to remember