### PR TITLE
Make `ExtremesHorizontalAxisItemPlacer` track the visible viewport

### DIFF
--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/axis/HorizontalAxisItemPlacers.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/axis/HorizontalAxisItemPlacers.kt
@@ -219,14 +219,18 @@ internal class ExtremesHorizontalAxisItemPlacer(private val shiftExtremeLines: B
     visibleXRange: ClosedFloatingPointRange<Double>,
     fullXRange: ClosedFloatingPointRange<Double>,
     maxLabelWidth: Float,
-  ): List<Double> = context.run { listOf(ranges.minX, ranges.maxX) }
+  ): List<Double> =
+    if (visibleXRange.start == visibleXRange.endInclusive) listOf(visibleXRange.start)
+    else listOf(visibleXRange.start, visibleXRange.endInclusive)
 
   override fun getLineValues(
     context: CartesianDrawingContext,
     visibleXRange: ClosedFloatingPointRange<Double>,
     fullXRange: ClosedFloatingPointRange<Double>,
     maxLabelWidth: Float,
-  ): List<Double> = context.run { listOf(ranges.minX, ranges.maxX) }
+  ): List<Double> =
+    if (visibleXRange.start == visibleXRange.endInclusive) listOf(visibleXRange.start)
+    else listOf(visibleXRange.start, visibleXRange.endInclusive)
 
   override fun getWidthMeasurementLabelValues(
     context: CartesianMeasuringContext,

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/axis/HorizontalAxisItemPlacers.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/axis/HorizontalAxisItemPlacers.kt
@@ -220,8 +220,11 @@ internal class ExtremesHorizontalAxisItemPlacer(private val shiftExtremeLines: B
     fullXRange: ClosedFloatingPointRange<Double>,
     maxLabelWidth: Float,
   ): List<Double> =
-    if (visibleXRange.start == visibleXRange.endInclusive) listOf(visibleXRange.start)
-    else listOf(visibleXRange.start, visibleXRange.endInclusive)
+    if (visibleXRange.start == visibleXRange.endInclusive) {
+      listOf(visibleXRange.start)
+    } else {
+      listOf(visibleXRange.start, visibleXRange.endInclusive)
+    }
 
   override fun getLineValues(
     context: CartesianDrawingContext,
@@ -229,8 +232,11 @@ internal class ExtremesHorizontalAxisItemPlacer(private val shiftExtremeLines: B
     fullXRange: ClosedFloatingPointRange<Double>,
     maxLabelWidth: Float,
   ): List<Double> =
-    if (visibleXRange.start == visibleXRange.endInclusive) listOf(visibleXRange.start)
-    else listOf(visibleXRange.start, visibleXRange.endInclusive)
+    if (visibleXRange.start == visibleXRange.endInclusive) {
+      listOf(visibleXRange.start)
+    } else {
+      listOf(visibleXRange.start, visibleXRange.endInclusive)
+    }
 
   override fun getWidthMeasurementLabelValues(
     context: CartesianMeasuringContext,

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/axis/HorizontalAxisItemPlacers.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/axis/HorizontalAxisItemPlacers.kt
@@ -219,14 +219,18 @@ internal class ExtremesHorizontalAxisItemPlacer(private val shiftExtremeLines: B
     visibleXRange: ClosedFloatingPointRange<Double>,
     fullXRange: ClosedFloatingPointRange<Double>,
     maxLabelWidth: Float,
-  ): List<Double> = context.run { listOf(ranges.minX, ranges.maxX) }
+  ): List<Double> =
+    if (visibleXRange.start == visibleXRange.endInclusive) listOf(visibleXRange.start)
+    else listOf(visibleXRange.start, visibleXRange.endInclusive)
 
   override fun getLineValues(
     context: CartesianDrawingContext,
     visibleXRange: ClosedFloatingPointRange<Double>,
     fullXRange: ClosedFloatingPointRange<Double>,
     maxLabelWidth: Float,
-  ): List<Double> = context.run { listOf(ranges.minX, ranges.maxX) }
+  ): List<Double> =
+    if (visibleXRange.start == visibleXRange.endInclusive) listOf(visibleXRange.start)
+    else listOf(visibleXRange.start, visibleXRange.endInclusive)
 
   override fun getWidthMeasurementLabelValues(
     context: CartesianMeasuringContext,

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/axis/HorizontalAxisItemPlacers.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/axis/HorizontalAxisItemPlacers.kt
@@ -220,8 +220,11 @@ internal class ExtremesHorizontalAxisItemPlacer(private val shiftExtremeLines: B
     fullXRange: ClosedFloatingPointRange<Double>,
     maxLabelWidth: Float,
   ): List<Double> =
-    if (visibleXRange.start == visibleXRange.endInclusive) listOf(visibleXRange.start)
-    else listOf(visibleXRange.start, visibleXRange.endInclusive)
+    if (visibleXRange.start == visibleXRange.endInclusive) {
+      listOf(visibleXRange.start)
+    } else {
+      listOf(visibleXRange.start, visibleXRange.endInclusive)
+    }
 
   override fun getLineValues(
     context: CartesianDrawingContext,
@@ -229,8 +232,11 @@ internal class ExtremesHorizontalAxisItemPlacer(private val shiftExtremeLines: B
     fullXRange: ClosedFloatingPointRange<Double>,
     maxLabelWidth: Float,
   ): List<Double> =
-    if (visibleXRange.start == visibleXRange.endInclusive) listOf(visibleXRange.start)
-    else listOf(visibleXRange.start, visibleXRange.endInclusive)
+    if (visibleXRange.start == visibleXRange.endInclusive) {
+      listOf(visibleXRange.start)
+    } else {
+      listOf(visibleXRange.start, visibleXRange.endInclusive)
+    }
 
   override fun getWidthMeasurementLabelValues(
     context: CartesianMeasuringContext,


### PR DESCRIPTION
`ExtremesHorizontalAxisItemPlacer` was placing labels and ticks at `ranges.minX`/`ranges.maxX` - the full dataset extents - instead of the visible viewport edges. This meant that when the chart was zoomed or scrolled, the labels appeared at the dataset boundaries rather than at the edges of what was actually visible.

`getLabelValues` and `getLineValues` now return `visibleXRange.start`/`visibleXRange.endInclusive` so the labels and ticks track the live viewport. Applied to both the Compose and Views stacks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patrykandpatrick/codesmith/vico/pr/1513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783356785&installation_id=136960981&pr_number=1513&repository=patrykandpatrick%2Fvico&return_to=https%3A%2F%2Fgithub.com%2Fpatrykandpatrick%2Fvico%2Fpull%2F1513&signature=2a3410e19f161848411636643583eaf80827717185f4441231abc895a5e56f3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->