### PR TITLE
Add separate initial-animation settings

### DIFF
--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -75,6 +75,8 @@ internal fun narrowMarkerTargets(
  * @param zoomState houses information on the [CartesianChart]’s zoom factor. Allows for zoom
  *   customization.
  * @param animationSpec the [AnimationSpec] for difference animations.
+ * @param initialAnimationSpec the [AnimationSpec] for the initial (reveal) animation. Defaults to
+ *   [animationSpec]. Set to `null` to skip the initial animation.
  * @param animateIn whether to run an initial animation when the [CartesianChartHost] enters
  *   composition. The animation is skipped for previews.
  * @param placeholder shown when no [CartesianChartModel] is available.
@@ -87,11 +89,19 @@ public fun CartesianChartHost(
   scrollState: VicoScrollState = rememberVicoScrollState(),
   zoomState: VicoZoomState = rememberDefaultVicoZoomState(scrollState.scrollEnabled),
   animationSpec: AnimationSpec<Float>? = defaultCartesianDiffAnimationSpec,
+  initialAnimationSpec: AnimationSpec<Float>? = animationSpec,
   animateIn: Boolean = true,
   placeholder: @Composable BoxScope.() -> Unit = {},
 ) {
   val mutableRanges = remember { MutableCartesianChartRanges() }
-  val modelWrapper by modelProducer.collectAsState(chart, animationSpec, animateIn, mutableRanges)
+  val modelWrapper by
+    modelProducer.collectAsState(
+      chart,
+      animationSpec,
+      initialAnimationSpec,
+      animateIn,
+      mutableRanges,
+    )
   val (model, previousModel, ranges, extraStore) = modelWrapper
 
   CartesianChartHostBox(modifier) {

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -77,8 +77,6 @@ internal fun narrowMarkerTargets(
  * @param animationSpec the [AnimationSpec] for difference animations.
  * @param initialAnimationSpec the [AnimationSpec] for the initial (reveal) animation. Defaults to
  *   [animationSpec]. Set to `null` to skip the initial animation.
- * @param animateIn whether to run an initial animation when the [CartesianChartHost] enters
- *   composition. The animation is skipped for previews.
  * @param placeholder shown when no [CartesianChartModel] is available.
  */
 @Composable
@@ -90,18 +88,11 @@ public fun CartesianChartHost(
   zoomState: VicoZoomState = rememberDefaultVicoZoomState(scrollState.scrollEnabled),
   animationSpec: AnimationSpec<Float>? = defaultCartesianDiffAnimationSpec,
   initialAnimationSpec: AnimationSpec<Float>? = animationSpec,
-  animateIn: Boolean = true,
   placeholder: @Composable BoxScope.() -> Unit = {},
 ) {
   val mutableRanges = remember { MutableCartesianChartRanges() }
   val modelWrapper by
-    modelProducer.collectAsState(
-      chart,
-      animationSpec,
-      initialAnimationSpec,
-      animateIn,
-      mutableRanges,
-    )
+    modelProducer.collectAsState(chart, animationSpec, initialAnimationSpec, mutableRanges)
   val (model, previousModel, ranges, extraStore) = modelWrapper
 
   CartesianChartHostBox(modifier) {
@@ -119,6 +110,45 @@ public fun CartesianChartHost(
       placeholder()
     }
   }
+}
+
+/**
+ * Displays a [CartesianChart].
+ *
+ * @param chart the [CartesianChart].
+ * @param modelProducer creates and updates the [CartesianChartModel].
+ * @param modifier the modifier to be applied to the chart.
+ * @param scrollState houses information on the [CartesianChart]’s scroll value. Allows for scroll
+ *   customization and programmatic scrolling.
+ * @param zoomState houses information on the [CartesianChart]’s zoom factor. Allows for zoom
+ *   customization.
+ * @param animationSpec the [AnimationSpec] for difference animations.
+ * @param animateIn whether to run an initial animation when the [CartesianChartHost] enters
+ *   composition. The animation is skipped for previews.
+ * @param placeholder shown when no [CartesianChartModel] is available.
+ */
+@Deprecated("Set `initialAnimationSpec` to `null` to skip the initial animation.")
+@Composable
+public fun CartesianChartHost(
+  chart: CartesianChart,
+  modelProducer: CartesianChartModelProducer,
+  modifier: Modifier = Modifier,
+  scrollState: VicoScrollState = rememberVicoScrollState(),
+  zoomState: VicoZoomState = rememberDefaultVicoZoomState(scrollState.scrollEnabled),
+  animationSpec: AnimationSpec<Float>? = defaultCartesianDiffAnimationSpec,
+  animateIn: Boolean,
+  placeholder: @Composable BoxScope.() -> Unit = {},
+) {
+  CartesianChartHost(
+    chart = chart,
+    modelProducer = modelProducer,
+    modifier = modifier,
+    scrollState = scrollState,
+    zoomState = zoomState,
+    animationSpec = animationSpec,
+    initialAnimationSpec = if (animateIn) animationSpec else null,
+    placeholder = placeholder,
+  )
 }
 
 /**

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/data/CartesianChartModel.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/data/CartesianChartModel.kt
@@ -109,7 +109,6 @@ internal fun CartesianChartModelProducer.collectAsState(
   chart: CartesianChart,
   animationSpec: AnimationSpec<Float>?,
   initialAnimationSpec: AnimationSpec<Float>?,
-  animateIn: Boolean,
   ranges: MutableCartesianChartRanges,
 ): State<CartesianChartData> {
   var previousHashCode by remember { ValueWrapper<Int?>(null) }
@@ -121,6 +120,8 @@ internal fun CartesianChartModelProducer.collectAsState(
   val isInPreview = LocalInspectionMode.current
   val scope = rememberCoroutineScope { getCoroutineContext(isInPreview) }
   val chartState = rememberWrappedValue(chart)
+  val animationSpecState = rememberUpdatedState(animationSpec)
+  val initialAnimationSpecState = rememberUpdatedState(initialAnimationSpec)
 
   fun updateRanges(model: CartesianChartModel?): CartesianChartRanges {
     ranges.reset()
@@ -138,7 +139,7 @@ internal fun CartesianChartModelProducer.collectAsState(
       model
     }
   }
-  LaunchRegistration(chart.id, animateIn, isInPreview) {
+  LaunchRegistration(chart.id, isInPreview) {
     var mainAnimationJob: Job? = null
     var animationFrameJob: Job? = null
     var finalAnimationFrameJob: Job? = null
@@ -148,9 +149,9 @@ internal fun CartesianChartModelProducer.collectAsState(
     val startAnimation: (transformModel: suspend (key: Any, fraction: Float) -> Unit) -> Unit =
       { transformModel ->
         val isInitial = isInitialAnimation && dataState.value.model == null
-        val spec = if (isInitial) initialAnimationSpec else animationSpec
+        val spec = if (isInitial) initialAnimationSpecState.value else animationSpecState.value
         isInitialAnimation = false
-        if (spec != null && !isInPreview && (dataState.value.model != null || animateIn)) {
+        if (spec != null && !isInPreview) {
           isAnimationRunning = true
           mainAnimationJob =
             scope.launch {
@@ -218,17 +219,12 @@ internal fun CartesianChartModelProducer.collectAsState(
 }
 
 @Composable
-private fun LaunchRegistration(
-  chartID: Uuid,
-  animateIn: Boolean,
-  isInPreview: Boolean,
-  block: () -> () -> Unit,
-) {
+private fun LaunchRegistration(chartID: Uuid, isInPreview: Boolean, block: () -> () -> Unit) {
   val runBlocking = runBlocking
   if (isInPreview && runBlocking != null) {
     runBlocking(getCoroutineContext(isPreview = true)) { block() }
   } else {
-    LaunchedEffect(chartID, animateIn) {
+    LaunchedEffect(chartID) {
       withContext(getCoroutineContext(isPreview = false)) {
         val disposable = block()
         currentCoroutineContext().job.invokeOnCompletion { disposable() }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/data/CartesianChartModel.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/data/CartesianChartModel.kt
@@ -109,6 +109,7 @@ internal val defaultCartesianDiffAnimationSpec: AnimationSpec<Float> =
 internal fun CartesianChartModelProducer.collectAsState(
   chart: CartesianChart,
   animationSpec: AnimationSpec<Float>?,
+  initialAnimationSpec: AnimationSpec<Float>?,
   animateIn: Boolean,
   ranges: MutableCartesianChartRanges,
 ): State<CartesianChartData> {
@@ -144,16 +145,20 @@ internal fun CartesianChartModelProducer.collectAsState(
     var finalAnimationFrameJob: Job? = null
     var isAnimationRunning: Boolean
     var isAnimationFrameGenerationRunning = false
+    var isInitialAnimation = true
     val startAnimation: (transformModel: suspend (key: Any, fraction: Float) -> Unit) -> Unit =
       { transformModel ->
-        if (animationSpec != null && !isInPreview && (dataState.value.model != null || animateIn)) {
+        val isInitial = isInitialAnimation && dataState.value.model == null
+        val spec = if (isInitial) initialAnimationSpec else animationSpec
+        isInitialAnimation = false
+        if (spec != null && !isInPreview && (dataState.value.model != null || animateIn)) {
           isAnimationRunning = true
           mainAnimationJob =
             scope.launch {
               animate(
                 initialValue = Animation.range.start,
                 targetValue = Animation.range.endInclusive,
-                animationSpec = animationSpec,
+                animationSpec = spec,
               ) { fraction, _ ->
                 when {
                   !isAnimationRunning -> return@animate

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/common/ChartView.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/common/ChartView.kt
@@ -65,6 +65,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
       interpolator = FastOutSlowInInterpolator()
     }
 
+  private var initialAnimationDuration: Long? = null
+  private var initialAnimationInterpolator: Interpolator? = null
+  private var isInitialAnimation = true
+
   protected val extraStore: MutableExtraStore = MutableExtraStore()
 
   protected var coroutineScope: CoroutineScope? = null
@@ -156,30 +160,52 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   protected fun startAnimation(transformModel: suspend (key: Any, fraction: Float) -> Unit) {
     if (model != null || animateIn) {
       handler?.post {
-        isAnimationRunning = true
-        animator.start { fraction ->
-          when {
-            !isAnimationRunning -> return@start
-            !isAnimationFrameGenerationRunning -> {
-              isAnimationFrameGenerationRunning = true
-              animationFrameJob =
-                coroutineScope?.launch {
-                  transformModel(this@ChartView, fraction)
-                  isAnimationFrameGenerationRunning = false
-                }
-            }
-            fraction == 1f -> {
-              finalAnimationFrameJob =
-                coroutineScope?.launch(Dispatchers.Default) {
-                  animationFrameJob?.cancelAndJoin()
-                  transformModel(this@ChartView, fraction)
-                  isAnimationFrameGenerationRunning = false
-                }
-            }
+        val isInitial = isInitialAnimation && model == null
+        isInitialAnimation = false
+        val onEnd: (() -> Unit)?
+        if (isInitial) {
+          val savedDuration = animator.duration
+          val savedInterpolator = animator.interpolator
+          initialAnimationDuration?.let { animator.duration = it }
+          initialAnimationInterpolator?.let { animator.interpolator = it }
+          // `ValueAnimator` reads its duration and interpolator per frame, and `start` only
+          // schedules the animation onto the next frame, so the initial duration and interpolator
+          // must remain in place until the animation ends rather than being restored synchronously.
+          onEnd = {
+            animator.duration = savedDuration
+            animator.interpolator = savedInterpolator
           }
+        } else {
+          onEnd = null
         }
+        isAnimationRunning = true
+        animator.start(
+          onEnd = onEnd,
+          block = block@{ fraction ->
+            when {
+              !isAnimationRunning -> return@block
+              !isAnimationFrameGenerationRunning -> {
+                isAnimationFrameGenerationRunning = true
+                animationFrameJob =
+                  coroutineScope?.launch {
+                    transformModel(this@ChartView, fraction)
+                    isAnimationFrameGenerationRunning = false
+                  }
+              }
+              fraction == 1f -> {
+                finalAnimationFrameJob =
+                  coroutineScope?.launch(Dispatchers.Default) {
+                    animationFrameJob?.cancelAndJoin()
+                    transformModel(this@ChartView, fraction)
+                    isAnimationFrameGenerationRunning = false
+                  }
+              }
+            }
+          },
+        )
       }
     } else {
+      isInitialAnimation = false
       finalAnimationFrameJob =
         coroutineScope?.launch { transformModel(this@ChartView, Animation.range.endInclusive) }
     }
@@ -195,6 +221,16 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   /** Sets the [Interpolator] for difference animations. */
   public fun setAnimationInterpolator(interpolator: Interpolator) {
     animator.interpolator = interpolator
+  }
+
+  /** Sets the duration (in milliseconds) of the initial (reveal) animation. */
+  public fun setInitialAnimationDuration(durationMillis: Long) {
+    initialAnimationDuration = durationMillis
+  }
+
+  /** Sets the [Interpolator] for the initial (reveal) animation. */
+  public fun setInitialAnimationInterpolator(interpolator: Interpolator) {
+    initialAnimationInterpolator = interpolator
   }
 
   override fun onRtlPropertiesChanged(layoutDirection: Int) {
@@ -227,7 +263,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   }
 }
 
-private fun ValueAnimator.start(block: (Float) -> Unit) {
+private fun ValueAnimator.start(onEnd: (() -> Unit)? = null, block: (Float) -> Unit) {
   val updateListener = ValueAnimator.AnimatorUpdateListener { block(it.animatedFraction) }
   addUpdateListener(updateListener)
   addListener(
@@ -235,6 +271,7 @@ private fun ValueAnimator.start(block: (Float) -> Unit) {
       override fun onAnimationCancel(animation: Animator) {
         removeUpdateListener(updateListener)
         removeListener(this)
+        onEnd?.invoke()
       }
 
       override fun onAnimationEnd(animation: Animator) {

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/common/ChartView.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/common/ChartView.kt
@@ -67,6 +67,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   private var initialAnimationDuration: Long? = null
   private var initialAnimationInterpolator: Interpolator? = null
   private var isInitialAnimation = true
+  private var isInitialAnimationEnabled = true
 
   protected val extraStore: MutableExtraStore = MutableExtraStore()
 
@@ -91,7 +92,12 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   private var shouldAcceptMotionEvents = false
 
   /** Whether to run an initial animation when the [ChartView] is created. */
-  public var animateIn: Boolean = true
+  @Deprecated("Call `setInitialAnimationDuration(0)` to skip the initial animation.")
+  public var animateIn: Boolean
+    get() = isInitialAnimationEnabled
+    set(value) {
+      isInitialAnimationEnabled = value
+    }
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
@@ -157,7 +163,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   }
 
   protected fun startAnimation(transformModel: suspend (key: Any, fraction: Float) -> Unit) {
-    if (model != null || animateIn) {
+    if (model != null || isInitialAnimationEnabled) {
       handler?.post {
         val isInitial = isInitialAnimation && model == null
         isInitialAnimation = false
@@ -181,26 +187,26 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         animator.start(
           onEnd = onEnd,
           block = block@{ fraction ->
-            when {
-              !isAnimationRunning -> return@block
-              !isAnimationFrameGenerationRunning -> {
-                isAnimationFrameGenerationRunning = true
-                animationFrameJob =
-                  coroutineScope?.launch {
-                    transformModel(this@ChartView, fraction)
-                    isAnimationFrameGenerationRunning = false
-                  }
+              when {
+                !isAnimationRunning -> return@block
+                !isAnimationFrameGenerationRunning -> {
+                  isAnimationFrameGenerationRunning = true
+                  animationFrameJob =
+                    coroutineScope?.launch {
+                      transformModel(this@ChartView, fraction)
+                      isAnimationFrameGenerationRunning = false
+                    }
+                }
+                fraction == 1f -> {
+                  finalAnimationFrameJob =
+                    coroutineScope?.launch(Dispatchers.Default) {
+                      animationFrameJob?.cancelAndJoin()
+                      transformModel(this@ChartView, fraction)
+                      isAnimationFrameGenerationRunning = false
+                    }
+                }
               }
-              fraction == 1f -> {
-                finalAnimationFrameJob =
-                  coroutineScope?.launch(Dispatchers.Default) {
-                    animationFrameJob?.cancelAndJoin()
-                    transformModel(this@ChartView, fraction)
-                    isAnimationFrameGenerationRunning = false
-                  }
-              }
-            }
-          },
+            },
         )
       }
     } else {


### PR DESCRIPTION
Give the first (reveal) animation its own timing, independent of difference animations. Adds `CartesianChartHost.initialAnimationSpec` (Compose) and `ChartView.setInitialAnimation{Duration,Interpolator}` (Views).

The Views path restores the initial duration and interpolator in the animator's end/cancel listener rather than synchronously after `start()`, since `ValueAnimator` reads them per frame and `start()` only schedules onto the next frame.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patrykandpatrick/codesmith/vico/pr/1514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783448801&installation_id=136960981&pr_number=1514&repository=patrykandpatrick%2Fvico&return_to=https%3A%2F%2Fgithub.com%2Fpatrykandpatrick%2Fvico%2Fpull%2F1514&signature=b91693f59fe87d23ed0f2544e8347459e5e2ecdf53000bfb11d86240f4aeb7c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->