### PR TITLE
Add per-type drawing-model interpolator factories

### DIFF
--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/CandlestickCartesianLayer.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/CandlestickCartesianLayer.kt
@@ -103,7 +103,7 @@ protected constructor(
         CandlestickCartesianLayerDrawingModel.Entry,
         CandlestickCartesianLayerDrawingModel,
       > =
-      CartesianLayerDrawingModelInterpolator.default(),
+      CartesianLayerDrawingModelInterpolator.candlestick(),
   ) : this(
     candleProvider,
     minCandleBodyHeight,
@@ -523,7 +523,7 @@ public fun rememberCandlestickCartesianLayer(
       CandlestickCartesianLayerDrawingModel.Entry,
       CandlestickCartesianLayerDrawingModel,
     > =
-    CartesianLayerDrawingModelInterpolator.default(),
+    CartesianLayerDrawingModelInterpolator.candlestick(),
 ): CandlestickCartesianLayer {
   var candlestickCartesianLayerWrapper by remember {
     ValueWrapper<CandlestickCartesianLayer?>(null)

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/ColumnCartesianLayer.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/ColumnCartesianLayer.kt
@@ -81,7 +81,7 @@ protected constructor(
       ColumnCartesianLayerDrawingModel.Entry,
       ColumnCartesianLayerDrawingModel,
     > =
-    CartesianLayerDrawingModelInterpolator.default(),
+    CartesianLayerDrawingModelInterpolator.column(),
   protected val drawingModelKey: ExtraStore.Key<ColumnCartesianLayerDrawingModel>,
 ) : BaseCartesianLayer<ColumnCartesianLayerModel>() {
   private val _markerTargets =
@@ -107,7 +107,7 @@ protected constructor(
         ColumnCartesianLayerDrawingModel.Entry,
         ColumnCartesianLayerDrawingModel,
       > =
-      CartesianLayerDrawingModelInterpolator.default(),
+      CartesianLayerDrawingModelInterpolator.column(),
   ) : this(
     columnProvider,
     columnCollectionSpacing,
@@ -717,7 +717,7 @@ public fun rememberColumnCartesianLayer(
       ColumnCartesianLayerDrawingModel,
     > =
     remember {
-      CartesianLayerDrawingModelInterpolator.default()
+      CartesianLayerDrawingModelInterpolator.column()
     },
 ): ColumnCartesianLayer {
   var columnCartesianLayerWrapper by remember { ValueWrapper<ColumnCartesianLayer?>(null) }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/LineCartesianLayer.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/LineCartesianLayer.kt
@@ -72,7 +72,7 @@ protected constructor(
       LineCartesianLayerDrawingModel.Entry,
       LineCartesianLayerDrawingModel,
     > =
-    CartesianLayerDrawingModelInterpolator.default(),
+    CartesianLayerDrawingModelInterpolator.line(),
   protected val drawingModelKey: ExtraStore.Key<LineCartesianLayerDrawingModel>,
 ) : BaseCartesianLayer<LineCartesianLayerModel>() {
   /**
@@ -519,7 +519,7 @@ protected constructor(
         LineCartesianLayerDrawingModel.Entry,
         LineCartesianLayerDrawingModel,
       > =
-      CartesianLayerDrawingModelInterpolator.default(),
+      CartesianLayerDrawingModelInterpolator.line(),
   ) : this(
     lineProvider,
     pointSpacing,
@@ -1053,7 +1053,7 @@ public fun rememberLineCartesianLayer(
       LineCartesianLayerDrawingModel,
     > =
     remember {
-      CartesianLayerDrawingModelInterpolator.default()
+      CartesianLayerDrawingModelInterpolator.line()
     },
 ): LineCartesianLayer {
   var lineCartesianLayerWrapper by remember { ValueWrapper<LineCartesianLayer?>(null) }

--- a/vico/compose/src/commonTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/data/CartesianLayerDrawingModelInterpolatorTest.kt
+++ b/vico/compose/src/commonTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/data/CartesianLayerDrawingModelInterpolatorTest.kt
@@ -26,11 +26,7 @@ import kotlin.test.assertEquals
 class CartesianLayerDrawingModelInterpolatorTest {
   @Test
   fun `Transform matches series by key`() {
-    val interpolator =
-      CartesianLayerDrawingModelInterpolator.default<
-        LineCartesianLayerDrawingModel.Entry,
-        LineCartesianLayerDrawingModel,
-      >()
+    val interpolator = CartesianLayerDrawingModelInterpolator.line()
     val oldModel =
       LineCartesianLayerDrawingModel(
         entries =

--- a/vico/shared/src/commonMain/kotlin/com/patrykandpatrick/vico/shared/common/data/CartesianLayerDrawingModelInterpolator.kt
+++ b/vico/shared/src/commonMain/kotlin/com/patrykandpatrick/vico/shared/common/data/CartesianLayerDrawingModelInterpolator.kt
@@ -54,23 +54,20 @@ public interface CartesianLayerDrawingModelInterpolator<
       CartesianLayerDrawingModelInterpolator<
         LineCartesianLayerDrawingModel.Entry,
         LineCartesianLayerDrawingModel,
-      > =
-      DefaultCartesianLayerDrawingModelInterpolator()
+      > = DefaultCartesianLayerDrawingModelInterpolator()
 
     /** Creates a [CartesianLayerDrawingModelInterpolator] for [ColumnCartesianLayer]s. */
     public fun column():
       CartesianLayerDrawingModelInterpolator<
         ColumnCartesianLayerDrawingModel.Entry,
         ColumnCartesianLayerDrawingModel,
-      > =
-      DefaultCartesianLayerDrawingModelInterpolator()
+      > = DefaultCartesianLayerDrawingModelInterpolator()
 
     /** Creates a [CartesianLayerDrawingModelInterpolator] for [CandlestickCartesianLayer]s. */
     public fun candlestick():
       CartesianLayerDrawingModelInterpolator<
         CandlestickCartesianLayerDrawingModel.Entry,
         CandlestickCartesianLayerDrawingModel,
-      > =
-      DefaultCartesianLayerDrawingModelInterpolator()
+      > = DefaultCartesianLayerDrawingModelInterpolator()
   }
 }

--- a/vico/shared/src/commonMain/kotlin/com/patrykandpatrick/vico/shared/common/data/CartesianLayerDrawingModelInterpolator.kt
+++ b/vico/shared/src/commonMain/kotlin/com/patrykandpatrick/vico/shared/common/data/CartesianLayerDrawingModelInterpolator.kt
@@ -16,6 +16,13 @@
 
 package com.patrykandpatrick.vico.shared.common.data
 
+import com.patrykandpatrick.vico.shared.cartesian.data.CandlestickCartesianLayerDrawingModel
+import com.patrykandpatrick.vico.shared.cartesian.data.ColumnCartesianLayerDrawingModel
+import com.patrykandpatrick.vico.shared.cartesian.data.LineCartesianLayerDrawingModel
+import com.patrykandpatrick.vico.shared.cartesian.layer.CandlestickCartesianLayer
+import com.patrykandpatrick.vico.shared.cartesian.layer.ColumnCartesianLayer
+import com.patrykandpatrick.vico.shared.cartesian.layer.LineCartesianLayer
+
 /** Interpolates two [CartesianLayerDrawingModel]s. */
 public interface CartesianLayerDrawingModelInterpolator<
   T : CartesianLayerDrawingModel.Entry,
@@ -31,12 +38,39 @@ public interface CartesianLayerDrawingModelInterpolator<
    */
   public suspend fun transform(fraction: Float): R?
 
-  /** Houses a [CartesianLayerDrawingModelInterpolator] factory function. */
+  /** Houses [CartesianLayerDrawingModelInterpolator] factory functions. */
   public companion object {
     /**
      * Creates an instance of the default [CartesianLayerDrawingModelInterpolator] implementation.
      */
+    @Deprecated(
+      "Use the per-`CartesianLayer`-type factory functions: `line`, `column`, and `candlestick`."
+    )
     public fun <T : CartesianLayerDrawingModel.Entry, R : CartesianLayerDrawingModel<T>> default():
       CartesianLayerDrawingModelInterpolator<T, R> = DefaultCartesianLayerDrawingModelInterpolator()
+
+    /** Creates a [CartesianLayerDrawingModelInterpolator] for [LineCartesianLayer]s. */
+    public fun line():
+      CartesianLayerDrawingModelInterpolator<
+        LineCartesianLayerDrawingModel.Entry,
+        LineCartesianLayerDrawingModel,
+      > =
+      DefaultCartesianLayerDrawingModelInterpolator()
+
+    /** Creates a [CartesianLayerDrawingModelInterpolator] for [ColumnCartesianLayer]s. */
+    public fun column():
+      CartesianLayerDrawingModelInterpolator<
+        ColumnCartesianLayerDrawingModel.Entry,
+        ColumnCartesianLayerDrawingModel,
+      > =
+      DefaultCartesianLayerDrawingModelInterpolator()
+
+    /** Creates a [CartesianLayerDrawingModelInterpolator] for [CandlestickCartesianLayer]s. */
+    public fun candlestick():
+      CartesianLayerDrawingModelInterpolator<
+        CandlestickCartesianLayerDrawingModel.Entry,
+        CandlestickCartesianLayerDrawingModel,
+      > =
+      DefaultCartesianLayerDrawingModelInterpolator()
   }
 }

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/CandlestickCartesianLayer.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/CandlestickCartesianLayer.kt
@@ -102,7 +102,7 @@ protected constructor(
         CandlestickCartesianLayerDrawingModel.Entry,
         CandlestickCartesianLayerDrawingModel,
       > =
-      CartesianLayerDrawingModelInterpolator.default(),
+      CartesianLayerDrawingModelInterpolator.candlestick(),
   ) : this(
     candleProvider,
     minCandleBodyHeightDp,

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/ColumnCartesianLayer.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/ColumnCartesianLayer.kt
@@ -73,7 +73,7 @@ protected constructor(
       ColumnCartesianLayerDrawingModel.Entry,
       ColumnCartesianLayerDrawingModel,
     > =
-    CartesianLayerDrawingModelInterpolator.default(),
+    CartesianLayerDrawingModelInterpolator.column(),
   protected val drawingModelKey: ExtraStore.Key<ColumnCartesianLayerDrawingModel>,
 ) : BaseCartesianLayer<ColumnCartesianLayerModel>() {
   private val _markerTargets =
@@ -99,7 +99,7 @@ protected constructor(
         ColumnCartesianLayerDrawingModel.Entry,
         ColumnCartesianLayerDrawingModel,
       > =
-      CartesianLayerDrawingModelInterpolator.default(),
+      CartesianLayerDrawingModelInterpolator.column(),
   ) : this(
     columnProvider,
     columnCollectionSpacingDp,

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/LineCartesianLayer.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/LineCartesianLayer.kt
@@ -64,7 +64,7 @@ protected constructor(
       LineCartesianLayerDrawingModel.Entry,
       LineCartesianLayerDrawingModel,
     > =
-    CartesianLayerDrawingModelInterpolator.default(),
+    CartesianLayerDrawingModelInterpolator.line(),
   protected val drawingModelKey: ExtraStore.Key<LineCartesianLayerDrawingModel>,
 ) : BaseCartesianLayer<LineCartesianLayerModel>() {
   /**
@@ -516,7 +516,7 @@ protected constructor(
         LineCartesianLayerDrawingModel.Entry,
         LineCartesianLayerDrawingModel,
       > =
-      CartesianLayerDrawingModelInterpolator.default(),
+      CartesianLayerDrawingModelInterpolator.line(),
   ) : this(
     lineProvider,
     pointSpacingDp,

--- a/vico/views/src/test/kotlin/com/patrykandpatrick/vico/views/cartesian/data/CartesianLayerDrawingModelInterpolatorTest.kt
+++ b/vico/views/src/test/kotlin/com/patrykandpatrick/vico/views/cartesian/data/CartesianLayerDrawingModelInterpolatorTest.kt
@@ -24,11 +24,7 @@ import kotlinx.coroutines.runBlocking
 class CartesianLayerDrawingModelInterpolatorTest {
   @Test
   fun `Transform matches series by key`() {
-    val interpolator =
-      CartesianLayerDrawingModelInterpolator.default<
-        LineCartesianLayerDrawingModel.Entry,
-        LineCartesianLayerDrawingModel,
-      >()
+    val interpolator = CartesianLayerDrawingModelInterpolator.line()
     val oldModel =
       LineCartesianLayerDrawingModel(
         entries =


### PR DESCRIPTION
Deprecate the generic `CartesianLayerDrawingModelInterpolator.default()` in favor of per-`CartesianLayer`-type factories: `line()`, `column()`, and `candlestick()`. Each returns an interpolator typed to its layer's drawing model, which is a type-safety improvement and the seam reveal builds on. No behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patrykandpatrick/codesmith/vico/pr/1515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->