### PR TITLE
Fix inverted area fill on scrolled Catmull-Rom charts (#1517)

### DIFF
--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/AreaFills.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/AreaFills.kt
@@ -32,6 +32,7 @@ import com.patrykandpatrick.vico.compose.common.getStart
 internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
   LineCartesianLayer.AreaFill {
   private val areaPath = Path()
+  private val translatedPath = Path()
 
   /**
    * Draws the area(s). [areaPath] is the region between the line and the split line; [canvasSplitY]
@@ -69,12 +70,15 @@ internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
   protected fun CartesianDrawingContext.fillArea(areaPath: Path, paint: Paint, fillBounds: Rect) {
     if (fillBounds.height <= 0f) return
     val (left, top) = fillBounds
+    // The brush is anchored at the origin and sized to `fillBounds`, so the canvas is translated to
+    // `fillBounds`’ top-left and a translated copy of the path is drawn (rather than mutating the
+    // shared `areaPath`, which `DoubleAreaFill` reuses across two draws).
+    translatedPath.rewind()
+    translatedPath.addPath(areaPath, Offset(-left, -top))
     canvas.withSave {
       canvas.clipRect(fillBounds)
       canvas.translate(left, top)
-      areaPath.translate(Offset(-left, -top))
-      canvas.drawPath(areaPath, paint)
-      areaPath.translate(Offset(left, top))
+      canvas.drawPath(translatedPath, paint)
     }
   }
 }
@@ -100,14 +104,16 @@ internal data class DoubleAreaFill(
   private val paint = Paint()
 
   override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
-    if (canvasSplitY > layerBounds.top) {
-      val bounds = Rect(layerBounds.left, layerBounds.top, layerBounds.right, canvasSplitY)
+    // `canvasSplitY` can fall slightly outside `layerBounds`, so the bands are clamped to it.
+    val splitY = canvasSplitY.coerceIn(layerBounds.top, layerBounds.bottom)
+    if (splitY > layerBounds.top) {
+      val bounds = Rect(layerBounds.left, layerBounds.top, layerBounds.right, splitY)
       paint.color = topFill.color
       topFill.brush?.applyTo(size = bounds.size, p = paint, alpha = 1f)
       fillArea(areaPath, paint, bounds)
     }
-    if (canvasSplitY < layerBounds.bottom) {
-      val bounds = Rect(layerBounds.left, canvasSplitY, layerBounds.right, layerBounds.bottom)
+    if (splitY < layerBounds.bottom) {
+      val bounds = Rect(layerBounds.left, splitY, layerBounds.right, layerBounds.bottom)
       paint.color = bottomFill.color
       bottomFill.brush?.applyTo(size = bounds.size, p = paint, alpha = 1f)
       fillArea(areaPath, paint, bounds)

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/AreaFills.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/AreaFills.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.PathOperation
 import androidx.compose.ui.graphics.withSave
 import com.patrykandpatrick.vico.compose.cartesian.CartesianDrawingContext
 import com.patrykandpatrick.vico.compose.cartesian.ColorScale
@@ -33,15 +32,13 @@ import com.patrykandpatrick.vico.compose.common.getStart
 internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
   LineCartesianLayer.AreaFill {
   private val areaPath = Path()
-  private val clipPath = Path()
 
-  open fun reset() {}
-
-  abstract fun onTopAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: Rect)
-
-  abstract fun onBottomAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: Rect)
-
-  open fun onAreasCreated(context: CartesianDrawingContext, fillBounds: Rect) {}
+  /**
+   * Draws the area(s). [areaPath] is the region between the line and the split line; [canvasSplitY]
+   * is the split line’s canvas _y_-coordinate. Implementations fill the relevant band(s) via
+   * [fillArea].
+   */
+  abstract fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float)
 
   override fun draw(
     context: CartesianDrawingContext,
@@ -49,39 +46,35 @@ internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
     halfLineThickness: Float,
     verticalAxisPosition: Axis.Position.Vertical?,
   ) {
-    reset()
     val areaBounds = linePath.getBounds()
     with(context) {
       val canvasSplitY = getCanvasSplitY(splitY, halfLineThickness, verticalAxisPosition)
-      if (canvasSplitY > layerBounds.top) {
-        clipPath.rewind()
-        val fillBounds = Rect(layerBounds.left, layerBounds.top, layerBounds.right, canvasSplitY)
-        clipPath.addRect(fillBounds, Path.Direction.Clockwise)
-        with(areaPath) {
-          rewind()
-          addPath(linePath)
-          lineTo(areaBounds.getEnd(isLtr), layerBounds.bottom)
-          lineTo(areaBounds.getStart(isLtr), layerBounds.bottom)
-          close()
-        }
-        areaPath.op(areaPath, clipPath, PathOperation.Intersect)
-        onTopAreasCreated(this, areaPath, fillBounds)
+      // The area fill is the region between the line and the split line. Closing the line path to
+      // the split line yields this region on both sides of the split. The fill is positioned and
+      // separated via canvas clipping (see `fillArea`) rather than a boolean path operation:
+      // `Path.op` can invert a self-intersecting subject, flipping the fill to the wrong side of
+      // the line. See https://github.com/patrykandpatrick/vico/issues/1517.
+      with(areaPath) {
+        rewind()
+        addPath(linePath)
+        lineTo(areaBounds.getEnd(isLtr), canvasSplitY)
+        lineTo(areaBounds.getStart(isLtr), canvasSplitY)
+        close()
       }
-      if (canvasSplitY < layerBounds.bottom) {
-        clipPath.rewind()
-        val fillBounds = Rect(layerBounds.left, canvasSplitY, layerBounds.right, layerBounds.bottom)
-        clipPath.addRect(fillBounds, Path.Direction.CounterClockwise)
-        with(areaPath) {
-          rewind()
-          addPath(linePath)
-          lineTo(areaBounds.getEnd(isLtr), layerBounds.top)
-          lineTo(areaBounds.getStart(isLtr), layerBounds.top)
-          close()
-        }
-        areaPath.op(areaPath, clipPath, PathOperation.Intersect)
-        onBottomAreasCreated(this, areaPath, fillBounds)
-      }
-      onAreasCreated(this, layerBounds)
+      drawAreas(areaPath, canvasSplitY)
+    }
+  }
+
+  /** Fills [areaPath] with [paint], clipped to and aligned with [fillBounds]. */
+  protected fun CartesianDrawingContext.fillArea(areaPath: Path, paint: Paint, fillBounds: Rect) {
+    if (fillBounds.height <= 0f) return
+    val (left, top) = fillBounds
+    canvas.withSave {
+      canvas.clipRect(fillBounds)
+      canvas.translate(left, top)
+      areaPath.translate(Offset(-left, -top))
+      canvas.drawPath(areaPath, paint)
+      areaPath.translate(Offset(left, top))
     }
   }
 }
@@ -91,35 +84,11 @@ internal data class SingleAreaFill(
   override val splitY: (ExtraStore) -> Number,
 ) : BaseAreaFill(splitY) {
   private val paint = Paint()
-  private val areaPath = Path()
 
-  override fun reset() {
-    areaPath.rewind()
-  }
-
-  override fun onTopAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: Rect) {
-    areaPath.addPath(path)
-  }
-
-  override fun onBottomAreasCreated(
-    context: CartesianDrawingContext,
-    path: Path,
-    fillBounds: Rect,
-  ) {
-    areaPath.addPath(path)
-  }
-
-  override fun onAreasCreated(context: CartesianDrawingContext, fillBounds: Rect) {
-    with(context) {
-      paint.color = fill.color
-      fill.brush?.applyTo(size = fillBounds.size, p = paint, alpha = 1f)
-      val (left, top) = fillBounds
-      canvas.withSave {
-        canvas.translate(left, top)
-        areaPath.translate(Offset(-left, -top))
-        canvas.drawPath(areaPath, paint)
-      }
-    }
+  override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
+    paint.color = fill.color
+    fill.brush?.applyTo(size = layerBounds.size, p = paint, alpha = 1f)
+    fillArea(areaPath, paint, layerBounds)
   }
 }
 
@@ -130,66 +99,27 @@ internal data class DoubleAreaFill(
 ) : BaseAreaFill(splitY) {
   private val paint = Paint()
 
-  override fun onTopAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: Rect) {
-    with(context) {
+  override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
+    if (canvasSplitY > layerBounds.top) {
+      val bounds = Rect(layerBounds.left, layerBounds.top, layerBounds.right, canvasSplitY)
       paint.color = topFill.color
-      topFill.brush?.applyTo(size = fillBounds.size, p = paint, alpha = 1f)
-      val (left, top) = fillBounds
-      canvas.withSave {
-        canvas.translate(left, top)
-        path.translate(Offset(-left, -top))
-        canvas.drawPath(path, paint)
-      }
+      topFill.brush?.applyTo(size = bounds.size, p = paint, alpha = 1f)
+      fillArea(areaPath, paint, bounds)
     }
-  }
-
-  override fun onBottomAreasCreated(
-    context: CartesianDrawingContext,
-    path: Path,
-    fillBounds: Rect,
-  ) {
-    with(context) {
+    if (canvasSplitY < layerBounds.bottom) {
+      val bounds = Rect(layerBounds.left, canvasSplitY, layerBounds.right, layerBounds.bottom)
       paint.color = bottomFill.color
-      bottomFill.brush?.applyTo(size = fillBounds.size, p = paint, alpha = 1f)
-      val (left, top) = fillBounds
-      canvas.withSave {
-        canvas.translate(left, top)
-        path.translate(Offset(-left, -top))
-        canvas.drawPath(path, paint)
-      }
+      bottomFill.brush?.applyTo(size = bounds.size, p = paint, alpha = 1f)
+      fillArea(areaPath, paint, bounds)
     }
   }
 }
 
 internal data class ColorScaleAreaFill(private val colorScale: ColorScale) : BaseAreaFill({ 0 }) {
   private val paint = Paint()
-  private val areaPath = Path()
 
-  override fun reset() {
-    areaPath.rewind()
-  }
-
-  override fun onTopAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: Rect) {
-    areaPath.addPath(path)
-  }
-
-  override fun onBottomAreasCreated(
-    context: CartesianDrawingContext,
-    path: Path,
-    fillBounds: Rect,
-  ) {
-    areaPath.addPath(path)
-  }
-
-  override fun onAreasCreated(context: CartesianDrawingContext, fillBounds: Rect) {
-    with(context) {
-      val (left, top) = fillBounds
-      paint.shader = colorScale.getColorScaleShader(context, top)
-      canvas.withSave {
-        canvas.translate(left, top)
-        areaPath.translate(Offset(-left, -top))
-        canvas.drawPath(areaPath, paint)
-      }
-    }
+  override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
+    paint.shader = colorScale.getColorScaleShader(this, layerBounds.top)
+    fillArea(areaPath, paint, layerBounds)
   }
 }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/AreaFills.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/AreaFills.kt
@@ -49,7 +49,11 @@ internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
   ) {
     val areaBounds = linePath.getBounds()
     with(context) {
-      val canvasSplitY = getCanvasSplitY(splitY, halfLineThickness, verticalAxisPosition)
+      // `getCanvasSplitY` can return a value slightly outside `layerBounds`; it's clamped so the
+      // polygon stays within the chart bounds.
+      val canvasSplitY =
+        getCanvasSplitY(splitY, halfLineThickness, verticalAxisPosition)
+          .coerceIn(layerBounds.top, layerBounds.bottom)
       // The area fill is the region between the line and the split line. Closing the line path to
       // the split line yields this region on both sides of the split. The fill is positioned and
       // separated via canvas clipping (see `fillArea`) rather than a boolean path operation:
@@ -68,7 +72,7 @@ internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
 
   /** Fills [areaPath] with [paint], clipped to and aligned with [fillBounds]. */
   protected fun CartesianDrawingContext.fillArea(areaPath: Path, paint: Paint, fillBounds: Rect) {
-    if (fillBounds.height <= 0f) return
+    if (fillBounds.width <= 0f || fillBounds.height <= 0f) return
     val (left, top) = fillBounds
     // The brush is anchored at the origin and sized to `fillBounds`, so the canvas is translated to
     // `fillBounds`’ top-left and a translated copy of the path is drawn (rather than mutating the
@@ -104,16 +108,15 @@ internal data class DoubleAreaFill(
   private val paint = Paint()
 
   override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
-    // `canvasSplitY` can fall slightly outside `layerBounds`, so the bands are clamped to it.
-    val splitY = canvasSplitY.coerceIn(layerBounds.top, layerBounds.bottom)
-    if (splitY > layerBounds.top) {
-      val bounds = Rect(layerBounds.left, layerBounds.top, layerBounds.right, splitY)
+    // `canvasSplitY` is already clamped to `layerBounds` by `BaseAreaFill`.
+    if (canvasSplitY > layerBounds.top) {
+      val bounds = Rect(layerBounds.left, layerBounds.top, layerBounds.right, canvasSplitY)
       paint.color = topFill.color
       topFill.brush?.applyTo(size = bounds.size, p = paint, alpha = 1f)
       fillArea(areaPath, paint, bounds)
     }
-    if (splitY < layerBounds.bottom) {
-      val bounds = Rect(layerBounds.left, splitY, layerBounds.right, layerBounds.bottom)
+    if (canvasSplitY < layerBounds.bottom) {
+      val bounds = Rect(layerBounds.left, canvasSplitY, layerBounds.right, layerBounds.bottom)
       paint.color = bottomFill.color
       bottomFill.brush?.applyTo(size = bounds.size, p = paint, alpha = 1f)
       fillArea(areaPath, paint, bounds)

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/CatmullRomInterpolator.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/CatmullRomInterpolator.kt
@@ -61,13 +61,16 @@ internal data class CatmullRomInterpolator(private val alpha: Float) :
     x2: Float,
     x3: Float,
   ) {
-    // The control points’ _x_-coordinates are clamped to [[x1, x2]]. With uneven point spacing,
-    // the raw values can fall outside this range, making the spline non-monotonic in _x_ (it
+    // The control points’ _x_-coordinates are clamped to the segment’s _x_-range. With uneven point
+    // spacing, the raw values can fall outside it, making the spline non-monotonic in _x_ (it
     // overshoots horizontally and doubles back). That produces a self-intersecting area-fill
     // polygon, which can invert the fill. See https://github.com/patrykandpatrick/vico/issues/1517.
-    val cp1x = (x1 + scale * (x2 - x0)).coerceIn(x1, x2)
+    // (`min`/`max` because _x_ decreases left-to-right when the layout direction is right-to-left.)
+    val minX = minOf(x1, x2)
+    val maxX = maxOf(x1, x2)
+    val cp1x = (x1 + scale * (x2 - x0)).coerceIn(minX, maxX)
     val cp1y = y1 + scale * (y2 - y0)
-    val cp2x = (x2 - scale * (x3 - x1)).coerceIn(x1, x2)
+    val cp2x = (x2 - scale * (x3 - x1)).coerceIn(minX, maxX)
     val cp2y = y2 - scale * (y3 - y1)
     path.cubicTo(cp1x, cp1y, cp2x, cp2y, x2, y2)
   }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/CatmullRomInterpolator.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/layer/CatmullRomInterpolator.kt
@@ -61,9 +61,13 @@ internal data class CatmullRomInterpolator(private val alpha: Float) :
     x2: Float,
     x3: Float,
   ) {
-    val cp1x = x1 + scale * (x2 - x0)
+    // The control points’ _x_-coordinates are clamped to [[x1, x2]]. With uneven point spacing,
+    // the raw values can fall outside this range, making the spline non-monotonic in _x_ (it
+    // overshoots horizontally and doubles back). That produces a self-intersecting area-fill
+    // polygon, which can invert the fill. See https://github.com/patrykandpatrick/vico/issues/1517.
+    val cp1x = (x1 + scale * (x2 - x0)).coerceIn(x1, x2)
     val cp1y = y1 + scale * (y2 - y0)
-    val cp2x = x2 - scale * (x3 - x1)
+    val cp2x = (x2 - scale * (x3 - x1)).coerceIn(x1, x2)
     val cp2y = y2 - scale * (y3 - y1)
     path.cubicTo(cp1x, cp1y, cp2x, cp2y, x2, y2)
   }

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/AreaFills.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/AreaFills.kt
@@ -95,14 +95,16 @@ internal data class DoubleAreaFill(
   private val bounds = RectF()
 
   override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
-    if (canvasSplitY > layerBounds.top) {
-      bounds.set(layerBounds.left, layerBounds.top, layerBounds.right, canvasSplitY)
+    // `canvasSplitY` can fall slightly outside `layerBounds`, so the bands are clamped to it.
+    val splitY = canvasSplitY.coerceIn(layerBounds.top, layerBounds.bottom)
+    if (splitY > layerBounds.top) {
+      bounds.set(layerBounds.left, layerBounds.top, layerBounds.right, splitY)
       paint.color = topFill.color
       paint.shader = topFill.shaderProvider?.getShader(this, bounds)
       fillArea(areaPath, paint, bounds)
     }
-    if (canvasSplitY < layerBounds.bottom) {
-      bounds.set(layerBounds.left, canvasSplitY, layerBounds.right, layerBounds.bottom)
+    if (splitY < layerBounds.bottom) {
+      bounds.set(layerBounds.left, splitY, layerBounds.right, layerBounds.bottom)
       paint.color = bottomFill.color
       paint.shader = bottomFill.shaderProvider?.getShader(this, bounds)
       fillArea(areaPath, paint, bounds)

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/AreaFills.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/AreaFills.kt
@@ -47,7 +47,11 @@ internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
   ) {
     @Suppress("DEPRECATION") linePath.computeBounds(areaBounds, false)
     with(context) {
-      val canvasSplitY = getCanvasSplitY(splitY, halfLineThickness, verticalAxisPosition)
+      // `getCanvasSplitY` can return a value slightly outside `layerBounds`; it's clamped so the
+      // polygon stays within the chart bounds.
+      val canvasSplitY =
+        getCanvasSplitY(splitY, halfLineThickness, verticalAxisPosition)
+          .coerceIn(layerBounds.top, layerBounds.bottom)
       // The area fill is the region between the line and the split line. Closing the line path to
       // the split line yields this region on both sides of the split. The fill is positioned and
       // separated via canvas clipping (see `fillArea`) rather than a boolean path operation:
@@ -65,7 +69,7 @@ internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
 
   /** Fills [areaPath] with [paint], clipped to [fillBounds]. */
   protected fun CartesianDrawingContext.fillArea(areaPath: Path, paint: Paint, fillBounds: RectF) {
-    if (fillBounds.height() <= 0f) return
+    if (fillBounds.width() <= 0f || fillBounds.height() <= 0f) return
     val checkpoint = canvas.save()
     canvas.clipRect(fillBounds)
     canvas.drawPath(areaPath, paint)
@@ -95,16 +99,15 @@ internal data class DoubleAreaFill(
   private val bounds = RectF()
 
   override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
-    // `canvasSplitY` can fall slightly outside `layerBounds`, so the bands are clamped to it.
-    val splitY = canvasSplitY.coerceIn(layerBounds.top, layerBounds.bottom)
-    if (splitY > layerBounds.top) {
-      bounds.set(layerBounds.left, layerBounds.top, layerBounds.right, splitY)
+    // `canvasSplitY` is already clamped to `layerBounds` by `BaseAreaFill`.
+    if (canvasSplitY > layerBounds.top) {
+      bounds.set(layerBounds.left, layerBounds.top, layerBounds.right, canvasSplitY)
       paint.color = topFill.color
       paint.shader = topFill.shaderProvider?.getShader(this, bounds)
       fillArea(areaPath, paint, bounds)
     }
-    if (splitY < layerBounds.bottom) {
-      bounds.set(layerBounds.left, splitY, layerBounds.right, layerBounds.bottom)
+    if (canvasSplitY < layerBounds.bottom) {
+      bounds.set(layerBounds.left, canvasSplitY, layerBounds.right, layerBounds.bottom)
       paint.color = bottomFill.color
       paint.shader = bottomFill.shaderProvider?.getShader(this, bounds)
       fillArea(areaPath, paint, bounds)

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/AreaFills.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/AreaFills.kt
@@ -31,16 +31,13 @@ internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
   LineCartesianLayer.AreaFill {
   private val areaBounds = RectF()
   private val areaPath = Path()
-  private val clipPath = Path()
-  private val fillBounds = RectF()
 
-  open fun reset() {}
-
-  abstract fun onTopAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: RectF)
-
-  abstract fun onBottomAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: RectF)
-
-  open fun onAreasCreated(context: CartesianDrawingContext, fillBounds: RectF) {}
+  /**
+   * Draws the area(s). [areaPath] is the region between the line and the split line; [canvasSplitY]
+   * is the split line’s canvas _y_-coordinate. Implementations fill the relevant band(s) via
+   * [fillArea].
+   */
+  abstract fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float)
 
   override fun draw(
     context: CartesianDrawingContext,
@@ -48,39 +45,31 @@ internal abstract class BaseAreaFill(open val splitY: (ExtraStore) -> Number) :
     halfLineThickness: Float,
     verticalAxisPosition: Axis.Position.Vertical?,
   ) {
-    reset()
     @Suppress("DEPRECATION") linePath.computeBounds(areaBounds, false)
     with(context) {
       val canvasSplitY = getCanvasSplitY(splitY, halfLineThickness, verticalAxisPosition)
-      if (canvasSplitY > layerBounds.top) {
-        clipPath.rewind()
-        fillBounds.set(layerBounds.left, layerBounds.top, layerBounds.right, canvasSplitY)
-        clipPath.addRect(fillBounds, Path.Direction.CW)
-        with(areaPath) {
-          set(linePath)
-          lineTo(areaBounds.getEnd(isLtr), layerBounds.bottom)
-          lineTo(areaBounds.getStart(isLtr), layerBounds.bottom)
-          close()
-          op(clipPath, Path.Op.INTERSECT)
-        }
-        onTopAreasCreated(this, areaPath, fillBounds)
+      // The area fill is the region between the line and the split line. Closing the line path to
+      // the split line yields this region on both sides of the split. The fill is positioned and
+      // separated via canvas clipping (see `fillArea`) rather than a boolean path operation:
+      // `Path.op` can invert a self-intersecting subject, flipping the fill to the wrong side of
+      // the line. See https://github.com/patrykandpatrick/vico/issues/1517.
+      with(areaPath) {
+        set(linePath)
+        lineTo(areaBounds.getEnd(isLtr), canvasSplitY)
+        lineTo(areaBounds.getStart(isLtr), canvasSplitY)
+        close()
       }
-      if (canvasSplitY < layerBounds.bottom) {
-        clipPath.rewind()
-        fillBounds.set(layerBounds.left, canvasSplitY, layerBounds.right, layerBounds.bottom)
-        clipPath.addRect(fillBounds, Path.Direction.CW)
-        with(areaPath) {
-          set(linePath)
-          lineTo(areaBounds.getEnd(isLtr), layerBounds.top)
-          lineTo(areaBounds.getStart(isLtr), layerBounds.top)
-          close()
-          op(clipPath, Path.Op.INTERSECT)
-        }
-        onBottomAreasCreated(this, areaPath, fillBounds)
-      }
-      fillBounds.set(layerBounds)
-      onAreasCreated(this, fillBounds)
+      drawAreas(areaPath, canvasSplitY)
     }
+  }
+
+  /** Fills [areaPath] with [paint], clipped to [fillBounds]. */
+  protected fun CartesianDrawingContext.fillArea(areaPath: Path, paint: Paint, fillBounds: RectF) {
+    if (fillBounds.height() <= 0f) return
+    val checkpoint = canvas.save()
+    canvas.clipRect(fillBounds)
+    canvas.drawPath(areaPath, paint)
+    canvas.restoreToCount(checkpoint)
   }
 }
 
@@ -89,30 +78,11 @@ internal data class SingleAreaFill(
   override val splitY: (ExtraStore) -> Number,
 ) : BaseAreaFill(splitY) {
   private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
-  private val areaPath = Path()
 
-  override fun reset() {
-    areaPath.rewind()
-  }
-
-  override fun onTopAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: RectF) {
-    areaPath.addPath(path)
-  }
-
-  override fun onBottomAreasCreated(
-    context: CartesianDrawingContext,
-    path: Path,
-    fillBounds: RectF,
-  ) {
-    areaPath.addPath(path)
-  }
-
-  override fun onAreasCreated(context: CartesianDrawingContext, fillBounds: RectF) {
-    with(context) {
-      paint.color = fill.color
-      paint.shader = fill.shaderProvider?.getShader(this, fillBounds)
-      canvas.drawPath(areaPath, paint)
-    }
+  override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
+    paint.color = fill.color
+    paint.shader = fill.shaderProvider?.getShader(this, layerBounds)
+    fillArea(areaPath, paint, layerBounds)
   }
 }
 
@@ -122,53 +92,30 @@ internal data class DoubleAreaFill(
   override val splitY: (ExtraStore) -> Number,
 ) : BaseAreaFill(splitY) {
   private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+  private val bounds = RectF()
 
-  override fun onTopAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: RectF) {
-    with(context) {
+  override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
+    if (canvasSplitY > layerBounds.top) {
+      bounds.set(layerBounds.left, layerBounds.top, layerBounds.right, canvasSplitY)
       paint.color = topFill.color
-      paint.shader = topFill.shaderProvider?.getShader(this, fillBounds)
-      canvas.drawPath(path, paint)
+      paint.shader = topFill.shaderProvider?.getShader(this, bounds)
+      fillArea(areaPath, paint, bounds)
     }
-  }
-
-  override fun onBottomAreasCreated(
-    context: CartesianDrawingContext,
-    path: Path,
-    fillBounds: RectF,
-  ) {
-    with(context) {
+    if (canvasSplitY < layerBounds.bottom) {
+      bounds.set(layerBounds.left, canvasSplitY, layerBounds.right, layerBounds.bottom)
       paint.color = bottomFill.color
-      paint.shader = bottomFill.shaderProvider?.getShader(this, fillBounds)
-      canvas.drawPath(path, paint)
+      paint.shader = bottomFill.shaderProvider?.getShader(this, bounds)
+      fillArea(areaPath, paint, bounds)
     }
   }
 }
 
 internal data class ColorScaleAreaFill(private val colorScale: ColorScale) : BaseAreaFill({ 0 }) {
   private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
-  private val areaPath = Path()
 
-  override fun reset() {
-    areaPath.rewind()
-  }
-
-  override fun onTopAreasCreated(context: CartesianDrawingContext, path: Path, fillBounds: RectF) {
-    areaPath.addPath(path)
-  }
-
-  override fun onBottomAreasCreated(
-    context: CartesianDrawingContext,
-    path: Path,
-    fillBounds: RectF,
-  ) {
-    areaPath.addPath(path)
-  }
-
-  override fun onAreasCreated(context: CartesianDrawingContext, fillBounds: RectF) {
-    with(context) {
-      paint.shader = colorScale.getColorScaleShader(context)
-      canvas.drawPath(areaPath, paint)
-    }
+  override fun CartesianDrawingContext.drawAreas(areaPath: Path, canvasSplitY: Float) {
+    paint.shader = colorScale.getColorScaleShader(this)
+    fillArea(areaPath, paint, layerBounds)
   }
 }
 

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/CatmullRomInterpolator.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/CatmullRomInterpolator.kt
@@ -61,13 +61,16 @@ internal data class CatmullRomInterpolator(private val alpha: Float) :
     x2: Float,
     x3: Float,
   ) {
-    // The control points’ _x_-coordinates are clamped to [[x1, x2]]. With uneven point spacing,
-    // the raw values can fall outside this range, making the spline non-monotonic in _x_ (it
+    // The control points’ _x_-coordinates are clamped to the segment’s _x_-range. With uneven point
+    // spacing, the raw values can fall outside it, making the spline non-monotonic in _x_ (it
     // overshoots horizontally and doubles back). That produces a self-intersecting area-fill
     // polygon, which can invert the fill. See https://github.com/patrykandpatrick/vico/issues/1517.
-    val cp1x = (x1 + scale * (x2 - x0)).coerceIn(x1, x2)
+    // (`min`/`max` because _x_ decreases left-to-right when the layout direction is right-to-left.)
+    val minX = minOf(x1, x2)
+    val maxX = maxOf(x1, x2)
+    val cp1x = (x1 + scale * (x2 - x0)).coerceIn(minX, maxX)
     val cp1y = y1 + scale * (y2 - y0)
-    val cp2x = (x2 - scale * (x3 - x1)).coerceIn(x1, x2)
+    val cp2x = (x2 - scale * (x3 - x1)).coerceIn(minX, maxX)
     val cp2y = y2 - scale * (y3 - y1)
     path.cubicTo(cp1x, cp1y, cp2x, cp2y, x2, y2)
   }

--- a/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/CatmullRomInterpolator.kt
+++ b/vico/views/src/main/kotlin/com/patrykandpatrick/vico/views/cartesian/layer/CatmullRomInterpolator.kt
@@ -61,9 +61,13 @@ internal data class CatmullRomInterpolator(private val alpha: Float) :
     x2: Float,
     x3: Float,
   ) {
-    val cp1x = x1 + scale * (x2 - x0)
+    // The control points’ _x_-coordinates are clamped to [[x1, x2]]. With uneven point spacing,
+    // the raw values can fall outside this range, making the spline non-monotonic in _x_ (it
+    // overshoots horizontally and doubles back). That produces a self-intersecting area-fill
+    // polygon, which can invert the fill. See https://github.com/patrykandpatrick/vico/issues/1517.
+    val cp1x = (x1 + scale * (x2 - x0)).coerceIn(x1, x2)
     val cp1y = y1 + scale * (y2 - y0)
-    val cp2x = x2 - scale * (x3 - x1)
+    val cp2x = (x2 - scale * (x3 - x1)).coerceIn(x1, x2)
     val cp2y = y2 - scale * (y3 - y1)
     path.cubicTo(cp1x, cp1y, cp2x, cp2y, x2, y2)
   }


### PR DESCRIPTION
Fixes #1517.

`AreaFill.single`/`AreaFill.double` could paint the area fill **above** the line instead of below it for certain scrolled/zoomed windows of a `catmullRom`-interpolated line (same symptom as #1257). The trigger is pixel-geometry dependent, so it surfaced deterministically on some densities and only transiently while scrolling on others.

## Root cause

Two independent issues combine to produce the inversion:

1. **`CatmullRomInterpolator` is not monotonic in _x_ at uneven spacing.** The Bézier control points' _x_-coordinates (`x1 + scale·(x2 − x0)` and `x2 − scale·(x3 − x1)`) can fall outside the segment's `[x1, x2]` range when neighboring points are unevenly/closely spaced. The spline then overshoots horizontally and doubles back, producing a **self-intersecting** area-fill polygon.

2. **`BaseAreaFill` relied on `Path.op(…, Intersect)`.** For a self-intersecting subject, Skia's path op can resolve the interior to the complement, flipping the fill to the wrong side of the line.

## Fix

- **Geometry (root cause):** clamp the Catmull-Rom control points' _x_-coordinates to `[x1, x2]`, keeping every segment monotonic in _x_. Evenly spaced points are unaffected, so existing charts render identically. (`CubicInterpolator` already keeps its control points in range.)
- **Rendering (hardening):** build the area fill as a single polygon between the line and the split line, and position/separate it with **canvas clipping** instead of a boolean path op. A degenerate subject can no longer invert the fill; at worst it yields a sub-pixel local artifact.

Both the **Compose** and **Android Views** stacks are updated.

## Verification

- The geometry fix was verified by driving the real `CatmullRomInterpolator` through Skia: with adversarial uneven spacing the unpatched interpolator doubles back in _x_; with the clamp it is monotonic, while evenly spaced input is monotonic either way.
- Both stacks compile and the existing `:vico:compose` and `:vico:views` unit-test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patrykandpatrick/codesmith/vico/pr/1520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783779228&installation_id=136960981&pr_number=1520&repository=patrykandpatrick%2Fvico&return_to=https%3A%2F%2Fgithub.com%2Fpatrykandpatrick%2Fvico%2Fpull%2F1520&signature=95d898c08f1c721b497ecd860cff8d47ef4c7bda1d8ce86a66355bf9b96c8b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->