### PR TITLE
feat(PieChart): add rotation via drag

### DIFF
--- a/sample/shared/src/commonMain/kotlin/com/patrykandpatrick/vico/sample/charts/BasicPieChart.kt
+++ b/sample/shared/src/commonMain/kotlin/com/patrykandpatrick/vico/sample/charts/BasicPieChart.kt
@@ -31,13 +31,16 @@ import com.patrykandpatrick.vico.compose.pie.PieChartHost
 import com.patrykandpatrick.vico.compose.pie.data.PieChartModelProducer
 import com.patrykandpatrick.vico.compose.pie.data.PieValueFormatter
 import com.patrykandpatrick.vico.compose.pie.data.pieModel
+import com.patrykandpatrick.vico.compose.pie.pieRotation
 import com.patrykandpatrick.vico.compose.pie.rememberPieChart
+import com.patrykandpatrick.vico.compose.pie.rememberPieRotationState
 
 @Composable
 private fun ComposeBasicPieChart(
   modelProducer: PieChartModelProducer,
   modifier: Modifier = Modifier,
 ) {
+  val rotation = rememberPieRotationState()
   PieChartHost(
     chart =
       rememberPieChart(
@@ -53,10 +56,11 @@ private fun ComposeBasicPieChart(
               )
             }
           ),
+        startAngle = -90f + rotation.angle,
         valueFormatter = PieValueFormatter { _, value, _ -> "${value.toInt()}%" },
       ),
     modelProducer = modelProducer,
-    modifier = modifier,
+    modifier = modifier.pieRotation(rotation),
   )
 }
 

--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/pie/PieRotationStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/pie/PieRotationStateTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.pie
+
+import androidx.compose.runtime.saveable.SaverScope
+import androidx.compose.ui.geometry.Offset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Timeout
+
+@Timeout(1)
+class PieRotationStateTest {
+  @Test
+  fun `When rotate is called, then the angle reaches the target`() = runBlocking {
+    val sut = PieRotationState(0f)
+
+    sut.rotate(90f)
+
+    assertEquals(90f, sut.angle)
+  }
+
+  @Test
+  fun `When the pointer sweeps a quarter turn, then angleDelta is 90 degrees`() {
+    val delta = angleDelta(Offset.Zero, Offset(1f, 0f), Offset(0f, 1f))
+
+    assertEquals(90f, delta, absoluteTolerance = 0.001f)
+  }
+
+  @Test
+  fun `When the pointer crosses the 180-degree seam, then angleDelta stays small`() {
+    val delta = angleDelta(Offset.Zero, Offset(-1f, -0.01f), Offset(-1f, 0.01f))
+
+    assertTrue(delta in -5f..5f, "Expected a small delta but got $delta")
+  }
+
+  @Test
+  fun `When state is saved and restored, then the angle is preserved`() {
+    val sut = PieRotationState(45f)
+    val saver = PieRotationState.Saver
+
+    val restored = saver.restore(with(saver) { SaverScope { true }.save(sut)!! })
+
+    assertEquals(45f, restored?.angle)
+  }
+}

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/pie/PieRotationState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/pie/PieRotationState.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.pie
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+
+/** Houses a [PieChart]’s rotation. Allows for rotation customization and programmatic rotation. */
+public class PieRotationState internal constructor(angle: Float) {
+  internal val animatable = Animatable(angle)
+
+  /** The current rotation (in degrees). */
+  public val angle: Float
+    get() = animatable.value
+
+  /** Rotates to [angle] (in degrees). */
+  public suspend fun rotate(angle: Float) {
+    animatable.snapTo(angle)
+  }
+
+  /** Triggers an animated rotation to [angle] (in degrees). */
+  public suspend fun animateRotate(angle: Float, animationSpec: AnimationSpec<Float> = spring()) {
+    animatable.animateTo(angle, animationSpec)
+  }
+
+  internal companion object {
+    val Saver: Saver<PieRotationState, Float> =
+      Saver(save = { it.angle }, restore = { PieRotationState(it) })
+  }
+}
+
+/**
+ * Creates and remembers a [PieRotationState] instance.
+ *
+ * @param initialAngle the initial rotation (in degrees).
+ */
+@Composable
+public fun rememberPieRotationState(initialAngle: Float = 0f): PieRotationState =
+  rememberSaveable(saver = PieRotationState.Saver) { PieRotationState(initialAngle) }
+
+/** Enables the rotation of a [PieChart] via drag, with fling. */
+@Composable
+public fun Modifier.pieRotation(state: PieRotationState): Modifier {
+  val decay = rememberSplineBasedDecay<Float>()
+  return pointerInput(state) {
+    coroutineScope {
+      val tracker = VelocityTracker()
+      var angle = 0f
+      detectDragGestures(
+        onDragStart = {
+          launch { state.animatable.stop() }
+          tracker.resetTracking()
+          angle = state.angle
+        },
+        onDragEnd = { launch { state.animatable.animateDecay(tracker.calculateVelocity().x, decay) } },
+      ) { change, _ ->
+        val center = Offset(size.width / 2f, size.height / 2f)
+        angle += angleDelta(center, change.previousPosition, change.position)
+        tracker.addPosition(change.uptimeMillis, Offset(angle, 0f))
+        launch { state.animatable.snapTo(angle) }
+        change.consume()
+      }
+    }
+  }
+}
+
+/** Returns the signed angle (in degrees) from [from] to [to] around [center], normalized to ±180°. */
+internal fun angleDelta(center: Offset, from: Offset, to: Offset): Float {
+  val a = from - center
+  val b = to - center
+  var delta = (atan2(b.y, b.x) - atan2(a.y, a.x)) * 180f / PI.toFloat()
+  if (delta > 180f) delta -= 360f else if (delta < -180f) delta += 360f
+  return delta
+}


### PR DESCRIPTION
The commit message is self explanatory. Here's a demo:

[Screen_recording_20260710_141829.webm](https://github.com/user-attachments/assets/bc5d9ad9-73db-49d8-890a-c50bb51be165)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patrykandpatrick/codesmith/vico/pr/1547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786274422&installation_id=136960981&pr_number=1547&repository=patrykandpatrick%2Fvico&return_to=https%3A%2F%2Fgithub.com%2Fpatrykandpatrick%2Fvico%2Fpull%2F1547&signature=9f21486d99de5dc240692780c18ddb9ae4bc3b12aaedf9cfc7545b2ba8e57786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->