### PR TITLE
fix: prevent UpdateReceiver leak when a chart's identity changes

### DIFF
--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/data/CartesianChartModel.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/data/CartesianChartModel.kt
@@ -139,7 +139,7 @@ internal fun CartesianChartModelProducer.collectAsState(
       model
     }
   }
-  LaunchRegistration(chart.id, isInPreview) {
+  LaunchRegistration(chart.id, isInPreview) { chartID ->
     var mainAnimationJob: Job? = null
     var animationFrameJob: Job? = null
     var finalAnimationFrameJob: Job? = null
@@ -166,7 +166,7 @@ internal fun CartesianChartModelProducer.collectAsState(
                     isAnimationFrameGenerationRunning = true
                     animationFrameJob =
                       scope.launch {
-                        transformModel(chartState.value.id, fraction)
+                        transformModel(chartID, fraction)
                         isAnimationFrameGenerationRunning = false
                       }
                   }
@@ -174,7 +174,7 @@ internal fun CartesianChartModelProducer.collectAsState(
                     finalAnimationFrameJob =
                       scope.launch(Dispatchers.Default) {
                         animationFrameJob?.cancelAndJoin()
-                        transformModel(chartState.value.id, fraction)
+                        transformModel(chartID, fraction)
                         isAnimationFrameGenerationRunning = false
                       }
                   }
@@ -183,12 +183,12 @@ internal fun CartesianChartModelProducer.collectAsState(
             }
         } else {
           finalAnimationFrameJob =
-            scope.launch { transformModel(chartState.value.id, Animation.range.endInclusive) }
+            scope.launch { transformModel(chartID, Animation.range.endInclusive) }
         }
       }
     scope.launch {
       registerForUpdates(
-        key = chartState.value.id,
+        key = chartID,
         restoredModel = restoredModel,
         cancelAnimation = {
           mainAnimationJob?.cancelAndJoin()
@@ -212,21 +212,25 @@ internal fun CartesianChartModelProducer.collectAsState(
       mainAnimationJob?.cancel()
       animationFrameJob?.cancel()
       finalAnimationFrameJob?.cancel()
-      unregisterFromUpdates(chartState.value.id)
+      unregisterFromUpdates(chartID)
     }
   }
   return dataState
 }
 
 @Composable
-private fun LaunchRegistration(chartID: Uuid, isInPreview: Boolean, block: () -> () -> Unit) {
+private fun LaunchRegistration(
+  chartID: Uuid,
+  isInPreview: Boolean,
+  block: (chartID: Uuid) -> () -> Unit,
+) {
   val runBlocking = runBlocking
   if (isInPreview && runBlocking != null) {
-    runBlocking(getCoroutineContext(isPreview = true)) { block() }
+    runBlocking(getCoroutineContext(isPreview = true)) { block(chartID) }
   } else {
     LaunchedEffect(chartID) {
       withContext(getCoroutineContext(isPreview = false)) {
-        val disposable = block()
+        val disposable = block(chartID)
         currentCoroutineContext().job.invokeOnCompletion { disposable() }
       }
     }


### PR DESCRIPTION
Use the effect-stable `chartID` instead of `chartState.value.id` when registering, transforming, and unregistering with `CartesianChartModelProducer`, since `chartState` mutates on every recomposition and could point at a new chart's id by the time the old effect disposes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patrykandpatrick/codesmith/vico/pr/1549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786298832&installation_id=136960981&pr_number=1549&repository=patrykandpatrick%2Fvico&return_to=https%3A%2F%2Fgithub.com%2Fpatrykandpatrick%2Fvico%2Fpull%2F1549&signature=8e1e4456849072358deff2298871d48e93b50d75c39c4a32d8ff0fce4292c6c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->