### PR TITLE
Fix scroll anchor drifting when data is trimmed on the start side

### DIFF
--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
@@ -208,6 +208,37 @@ class VicoScrollStateTest {
     assertEquals(-20f, sut.value)
   }
 
+  @Test
+  fun `When data is trimmed on the start side while pinned to the end, then update keeps the scroll pinned to the end`() =
+    runBlocking {
+      maxX = 19.0
+      xLength = 19.0
+      val bounds = Rect(0f, 0f, 100f, 100f)
+      val layerDimensions =
+        MutableCartesianLayerDimensions(
+          xSpacing = 10f,
+          scalableStartPadding = 6f,
+          unscalableStartPadding = 4f,
+        )
+      // The initial content is 100px wider than the chart, so the end-pinned scroll value is 100,
+      // matching the max scroll distance. The scroll is at the end.
+      val sut = createScrollState(initialScroll = Scroll.Absolute.End, layerDimensions = layerDimensions)
+      assertEquals(sut.maxValue, sut.value)
+
+      val visibleStart = context.getVisibleXRange(layerDimensions, bounds, sut.value).start
+
+      // Trim the five oldest points. The remaining content still overflows the chart, so the new
+      // max scroll distance is smaller than the old scroll value.
+      minX = 5.0
+      xLength = 14.0
+      sut.update(context = context, bounds = bounds, layerDimensions = layerDimensions)
+
+      // The visible x range is unchanged (the trimmed points were off-screen), and the scroll stays
+      // pinned to the end rather than rolling toward the start by the size of the trim.
+      assertEquals(visibleStart, context.getVisibleXRange(layerDimensions, bounds, sut.value).start)
+      assertEquals(sut.maxValue, sut.value)
+    }
+
   private fun createScrollState(
     xSnapStep: Double? = null,
     initialScroll: Scroll.Absolute = Scroll.Absolute.Start,

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -168,6 +168,13 @@ public class VicoScrollState {
     this.context = context
     this.layerDimensions = layerDimensions
     this.bounds = bounds
+    // Capture the scroll value before updating `maxValue`. The `maxValue` setter clamps `value` to
+    // the new maximum, so when the content shrinks on the start side (e.g., the data window was
+    // trimmed) while the scroll is pinned to the end (`value == maxValue`), the clamp shifts
+    // `value` back by the trimmed amount before the repositioning below runs. The repositioning
+    // would then compute `startEdgeX` from the already-clamped value and roll the viewport toward
+    // the start by the size of the trim.
+    val preClampValue = value
     maxValue = context.getMaxScrollDistance(bounds.width, layerDimensions)
     val ranges = context.ranges
     val previous = previousScrollLayout
@@ -182,7 +189,8 @@ public class VicoScrollState {
     ) {
       val startEdgeX =
         previous.minX +
-          (previous.layoutDirectionMultiplier * value - previous.startPadding) / previous.xSpacing *
+          (previous.layoutDirectionMultiplier * preClampValue - previous.startPadding) /
+            previous.xSpacing *
             previous.xStep
       value =
         context.layoutDirectionMultiplier *


### PR DESCRIPTION
  ## Summary                                                                                                                                                                         
                                                                                                                                                                                     
  After a zoom gesture, the viewport can jump back to the position it had at the moment the zoom started if a pan or fling begins without the scroll ever becoming idle (e.g. a pinch that transitions straight into a pan).                                                                                                                 
                                                                                                                                                                                     
  ## Cause                                                                                                                                                                           
                                                                                                                                                                                     
  `VicoScrollState.scroll(scroll, maxScroll)` receives the zoom's scroll compensation — an absolute target computed from the scroll value and content width at the time of the zoom event. It waits for the scroll to become idle (`isScrollInProgress.first { !it }`) before applying it. If the scroll never goes idle, by the time it runs both the target and  `maxScroll` are stale, so applying them rolls the viewport back to the zoom-time position.                                                                                                                            
                                                                                                                                                                                     
  ## Fix                                                                                                                                                                             
                                                                                                                                                                                     
  Skip the compensation when a scroll is already in progress. The zoom handler emits a fresh compensation on every zoom event, so dropping a stale one is safe.                                                                                                   
                                                                                                                                                                                     
  ## Testing                                                                                                                                                                         
                                                                                                                                                                                     
  Added `VicoScrollStateTest` case: with a scroll in progress, `scroll(scroll, maxScroll)` returns without touching `maxValue`. Without the fix the call suspends until the scroll ends and the test times out.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patrykandpatrick/codesmith/vico/pr/1553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786606412&installation_id=136960981&pr_number=1553&repository=patrykandpatrick%2Fvico&return_to=https%3A%2F%2Fgithub.com%2Fpatrykandpatrick%2Fvico%2Fpull%2F1553&signature=17e52d3b67a082c940e5991246af9c799c15cae223d60e147c67e7c7642c10c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->