### PR TITLE
Fix two scroll-position regressions in VicoScrollState

### DIFF
--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
@@ -208,6 +208,37 @@ class VicoScrollStateTest {
     assertEquals(-20f, sut.value)
   }
 
+  @Test
+  fun `When data is trimmed on the start side while pinned to the end, then update keeps the scroll pinned to the end`() =
+    runBlocking {
+      maxX = 19.0
+      xLength = 19.0
+      val bounds = Rect(0f, 0f, 100f, 100f)
+      val layerDimensions =
+        MutableCartesianLayerDimensions(
+          xSpacing = 10f,
+          scalableStartPadding = 6f,
+          unscalableStartPadding = 4f,
+        )
+      // The initial content is 100px wider than the chart, so the end-pinned scroll value is 100,
+      // matching the max scroll distance. The scroll is at the end.
+      val sut = createScrollState(initialScroll = Scroll.Absolute.End, layerDimensions = layerDimensions)
+      assertEquals(sut.maxValue, sut.value)
+
+      val visibleStart = context.getVisibleXRange(layerDimensions, bounds, sut.value).start
+
+      // Trim the five oldest points. The remaining content still overflows the chart, so the new
+      // max scroll distance is smaller than the old scroll value.
+      minX = 5.0
+      xLength = 14.0
+      sut.update(context = context, bounds = bounds, layerDimensions = layerDimensions)
+
+      // The visible x range is unchanged (the trimmed points were off-screen), and the scroll stays
+      // pinned to the end rather than rolling toward the start by the size of the trim.
+      assertEquals(visibleStart, context.getVisibleXRange(layerDimensions, bounds, sut.value).start)
+      assertEquals(sut.maxValue, sut.value)
+    }
+
   private fun createScrollState(
     xSnapStep: Double? = null,
     initialScroll: Scroll.Absolute = Scroll.Absolute.Start,

--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
@@ -223,7 +224,8 @@ class VicoScrollStateTest {
         )
       // The initial content is 100px wider than the chart, so the end-pinned scroll value is 100,
       // matching the max scroll distance. The scroll is at the end.
-      val sut = createScrollState(initialScroll = Scroll.Absolute.End, layerDimensions = layerDimensions)
+      val sut =
+        createScrollState(initialScroll = Scroll.Absolute.End, layerDimensions = layerDimensions)
       assertEquals(sut.maxValue, sut.value)
 
       val visibleStart = context.getVisibleXRange(layerDimensions, bounds, sut.value).start
@@ -241,24 +243,39 @@ class VicoScrollStateTest {
     }
 
   @Test
-  fun `When a scroll is in progress, then scroll with a max value is skipped`() = runBlocking {
-    val sut = createScrollState()
-    val maxValueBefore = sut.maxValue
-    // Hold a scroll in progress so isScrollInProgress stays true for the duration of the test.
-    val holdJob =
+  fun `When a scroll is in progress, then a zoom's pending scroll is dropped`() = runBlocking {
+    val scrollState = createScrollState()
+    val zoomState = createZoomState()
+    val maxValueBefore = scrollState.maxValue
+
+    // Mirror CartesianChartHost's wiring: the zoom state's pending scroll flows into the scroll
+    // state. `processed` completes only once the collector returns from `scroll`, so awaiting it
+    // catches the pre-fix behavior, where `scroll` suspends until the in-progress scroll ends.
+    val processed = CompletableDeferred<Unit>()
+    val collector =
       launch(start = CoroutineStart.UNDISPATCHED) {
-        sut.scrollableState.scroll { suspendCancellableCoroutine<Unit> {} }
+        zoomState.pendingScroll.collect { (scroll, maxValue) ->
+          scrollState.scroll(scroll, maxValue)
+          processed.complete(Unit)
+        }
       }
-    assertTrue(sut.scrollableState.isScrollInProgress)
 
-    // A zoom emits stale scroll compensation with its own max value. It must be dropped rather than
-    // applied once the scroll stops, so maxValue is left untouched. (Without the fix this would
-    // suspend until the scroll ends and time out.)
-    sut.scroll(Scroll.Absolute.pixels(0f), maxScroll = maxValueBefore + 500f)
+    // Begin a scroll and keep it in progress.
+    val scrollJob =
+      launch(start = CoroutineStart.UNDISPATCHED) {
+        scrollState.scrollableState.scroll { suspendCancellableCoroutine<Unit> {} }
+      }
+    assertTrue(scrollState.scrollableState.isScrollInProgress)
 
-    assertEquals(maxValueBefore, sut.maxValue)
+    // A zoom emits scroll compensation while the scroll is in progress. The compensation is stale,
+    // so it must be dropped rather than applied, leaving maxValue untouched.
+    zoomState.zoom(factor = 2f, centroidX = 50f) { scrollState.value }
+    processed.await()
 
-    holdJob.cancelAndJoin()
+    assertEquals(maxValueBefore, scrollState.maxValue)
+
+    scrollJob.cancelAndJoin()
+    collector.cancelAndJoin()
   }
 
   private fun createScrollState(
@@ -283,6 +300,22 @@ class VicoScrollStateTest {
           layerDimensions = layerDimensions,
         )
         it.maxValue = 100f
+      }
+
+  private fun createZoomState(): VicoZoomState =
+    VicoZoomState(
+        zoomEnabled = true,
+        initialZoom = Zoom.fixed(1f),
+        minZoom = Zoom.fixed(1f),
+        maxZoom = Zoom.fixed(4f),
+      )
+      .also {
+        it.update(
+          context = context,
+          layerDimensions = MutableCartesianLayerDimensions(xSpacing = 10f),
+          bounds = Rect(0f, 0f, 100f, 100f),
+          scroll = 0f,
+        )
       }
 
   private class SuspendingFrameClock : MonotonicFrameClock {

--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
@@ -238,6 +239,27 @@ class VicoScrollStateTest {
       assertEquals(visibleStart, context.getVisibleXRange(layerDimensions, bounds, sut.value).start)
       assertEquals(sut.maxValue, sut.value)
     }
+
+  @Test
+  fun `When a scroll is in progress, then scroll with a max value is skipped`() = runBlocking {
+    val sut = createScrollState()
+    val maxValueBefore = sut.maxValue
+    // Hold a scroll in progress so isScrollInProgress stays true for the duration of the test.
+    val holdJob =
+      launch(start = CoroutineStart.UNDISPATCHED) {
+        sut.scrollableState.scroll { suspendCancellableCoroutine<Unit> {} }
+      }
+    assertTrue(sut.scrollableState.isScrollInProgress)
+
+    // A zoom emits stale scroll compensation with its own max value. It must be dropped rather than
+    // applied once the scroll stops, so maxValue is left untouched. (Without the fix this would
+    // suspend until the scroll ends and time out.)
+    sut.scroll(Scroll.Absolute.pixels(0f), maxScroll = maxValueBefore + 500f)
+
+    assertEquals(maxValueBefore, sut.maxValue)
+
+    holdJob.cancelAndJoin()
+  }
 
   private fun createScrollState(
     xSnapStep: Double? = null,

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -190,8 +190,7 @@ public class VicoScrollState {
       val startEdgeX =
         previous.minX +
           (previous.layoutDirectionMultiplier * preClampValue - previous.startPadding) /
-            previous.xSpacing *
-            previous.xStep
+            previous.xSpacing * previous.xStep
       value =
         context.layoutDirectionMultiplier *
           (layerDimensions.startPadding +
@@ -229,13 +228,13 @@ public class VicoScrollState {
   }
 
   internal suspend fun scroll(scroll: Scroll, maxScroll: Float) {
-    // This receives the scroll compensation for a zoom gesture—an absolute target computed from the
-    // scroll value and the content width at the time of the zoom event. It’s valid only while the
-    // user isn’t scrolling: if a pan or fling is already in progress (e.g., the pinch turned into a
-    // pan without the scroll ever becoming idle for a frame), then by the time the scroll stops both
-    // the target and `maxScroll` are stale, and applying them would roll the viewport back to the
-    // position at the time of the zoom. Drop the stale compensation; the zoom handler emits a fresh
-    // one on every zoom event.
+    // This receives the scroll compensation for a zoom gesture—an absolute target computed
+    // from the scroll value and the content width at the time of the zoom event. It’s valid
+    // only while the user isn’t scrolling: if a pan or fling is already in progress (e.g., the
+    // pinch turned into a pan without the scroll ever becoming idle for a frame), then by the
+    // time the scroll stops, the target and `maxScroll` are stale, and applying them would
+    // roll the viewport back to the position at the time of the zoom. Drop the stale
+    // compensation; the zoom handler emits a fresh one on every zoom event.
     if (scrollableState.isScrollInProgress) return
     maxValue = maxScroll
     withUpdated { context, layerDimensions, bounds ->

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -168,6 +168,13 @@ public class VicoScrollState {
     this.context = context
     this.layerDimensions = layerDimensions
     this.bounds = bounds
+    // Capture the scroll value before updating `maxValue`. The `maxValue` setter clamps `value` to
+    // the new maximum, so when the content shrinks on the start side (e.g., the data window was
+    // trimmed) while the scroll is pinned to the end (`value == maxValue`), the clamp shifts
+    // `value` back by the trimmed amount before the repositioning below runs. The repositioning
+    // would then compute `startEdgeX` from the already-clamped value and roll the viewport toward
+    // the start by the size of the trim.
+    val preClampValue = value
     maxValue = context.getMaxScrollDistance(bounds.width, layerDimensions)
     val ranges = context.ranges
     val previous = previousScrollLayout
@@ -182,7 +189,8 @@ public class VicoScrollState {
     ) {
       val startEdgeX =
         previous.minX +
-          (previous.layoutDirectionMultiplier * value - previous.startPadding) / previous.xSpacing *
+          (previous.layoutDirectionMultiplier * preClampValue - previous.startPadding) /
+            previous.xSpacing *
             previous.xStep
       value =
         context.layoutDirectionMultiplier *

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -229,7 +229,14 @@ public class VicoScrollState {
   }
 
   internal suspend fun scroll(scroll: Scroll, maxScroll: Float) {
-    isScrollInProgress.first { !it }
+    // This receives the scroll compensation for a zoom gesture—an absolute target computed from the
+    // scroll value and the content width at the time of the zoom event. It’s valid only while the
+    // user isn’t scrolling: if a pan or fling is already in progress (e.g., the pinch turned into a
+    // pan without the scroll ever becoming idle for a frame), then by the time the scroll stops both
+    // the target and `maxScroll` are stale, and applying them would roll the viewport back to the
+    // position at the time of the zoom. Drop the stale compensation; the zoom handler emits a fresh
+    // one on every zoom event.
+    if (scrollableState.isScrollInProgress) return
     maxValue = maxScroll
     withUpdated { context, layerDimensions, bounds ->
       scrollableState.scrollBy(scroll.getDelta(context, layerDimensions, bounds, maxValue, value))


### PR DESCRIPTION
## Summary                                                                                                                                                                         
                                                                                                                                                                                     
  Two independent scroll-correctness fixes in `VicoScrollState`, one per commit. Follow-up to #1539 (visible x range preservation).                                                                                                                                 
                                                                                                                                                                                     
  ## 1. Scroll anchor drifts when data is trimmed on the start side                                                                                                                  
                                                                                                                                                                                     
  When data is trimmed on the start side while the scroll is pinned to the end, the viewport rolls toward the start by the size  of the trim instead of staying put.                                                                                                                                                                               
                                                                                                                                                                                     
  **Cause:** In `update`, the scroll `value` used to compute the anchor's start-edge x coordinate is read *after* `maxValue` is updated. The `maxValue` setter clamps `value` to the new maximum, so when the content shrinks on the start side (the  max scroll distance drops below the current, end-pinned `value`), the clamp shifts `value` back *before* the repositioning runs. The repositioning then computes `startEdgeX` from the already-clamped value and offsets the viewport by the trimmed amount.                                                                                                                                                    
                                                                                                                                                                                     
  **Fix:** Capture the pre-clamp value and use it when computing `startEdgeX`. RTL handling (`layoutDirectionMultiplier`) is preserved.
  
  ## 2. Stale zoom scroll compensation applied after a scroll                                                                                                                        
                                                                                                                                                                                     
  After a zoom, the viewport can jump back to its zoom-time position if a pan or fling starts without the scroll ever becoming idle (e.g. a pinch that transitions straight into a pan).                                                                                                                                                  
                                                                                                                                                                                     
  **Cause:** `scroll(scroll, maxScroll)` receives the zoom's scroll compensation — an absolute target computed from the scroll value and content width at the time of the zoom event — and waits for the scroll to become idle (`isScrollInProgress.first { !it }`) before applying it. If the scroll never goes idle, both the target and `maxScroll` are stale by the time it runs, so applying them rolls the viewport back to the zoom-time position.                                                                                                                            
                                                                                                                                                                                     
  **Fix:** Skip the compensation when a scroll is already in progress. The zoom handler emits a fresh compensation on every zoom event, so dropping a stale one is safe.                                                                                                                                                                           
                                                                                                                                                                                     
  ## Testing                                                                                                                                                                         
                                                                                                                                                                                     
  Added a `VicoScrollStateTest` case for each fix. Both fail without their respective fix (the viewport rolls left / the call times out) and pass with it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patrykandpatrick/codesmith/vico/pr/1554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786608468&installation_id=136960981&pr_number=1554&repository=patrykandpatrick%2Fvico&return_to=https%3A%2F%2Fgithub.com%2Fpatrykandpatrick%2Fvico%2Fpull%2F1554&signature=0a21ffaa946ee9bbd4dede45c0ab249757b43134ec5d239f86a48cf0a913b591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->