### PR TITLE
ci: use Claude Opus 5 in workflows

### DIFF
--- a/.github/workflows/dispatch-claude.yml
+++ b/.github/workflows/dispatch-claude.yml
@@ -55,4 +55,4 @@ jobs:
             Operator request:
 
             ${{ github.event.inputs.request }}
-          claude_args: --model claude-opus-4-8
+          claude_args: --model claude-opus-5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: --model claude-opus-4-8 --add-dir "${{ github.workspace }}/vico"
+          claude_args: --model claude-opus-5 --add-dir "${{ github.workspace }}/vico"
           settings: |
             {
               "permissions": {

--- a/.github/workflows/validate-bug-report.yml
+++ b/.github/workflows/validate-bug-report.yml
@@ -62,4 +62,4 @@ jobs:
                ```sh
                gh issue close ${{ github.event.inputs.issue_number }} --repo ${{ github.repository }} --reason "not planned"
                ```
-          claude_args: --model claude-opus-4-8
+          claude_args: --model claude-opus-5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Claude Code model in GitHub Actions from `claude-opus-4-8` to `claude-opus-5`.

Affected workflows:
- `dispatch-claude.yml`
- `publish.yml`
- `validate-bug-report.yml`

No other workflow settings need to change for this model swap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f14f90ae-f526-4564-baa8-21bf1927daff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f14f90ae-f526-4564-baa8-21bf1927daff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>