### PR TITLE
fix(compose): apply zoom and its scroll compensation atomically

### DIFF
--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollStateTest.kt
@@ -30,8 +30,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
@@ -242,42 +240,6 @@ class VicoScrollStateTest {
       assertEquals(sut.maxValue, sut.value)
     }
 
-  @Test
-  fun `When a scroll is in progress, then a zoom's pending scroll is dropped`() = runBlocking {
-    val scrollState = createScrollState()
-    val zoomState = createZoomState()
-    val maxValueBefore = scrollState.maxValue
-
-    // Mirror CartesianChartHost's wiring: the zoom state's pending scroll flows into the scroll
-    // state. `processed` completes only once the collector returns from `scroll`, so awaiting it
-    // catches the pre-fix behavior, where `scroll` suspends until the in-progress scroll ends.
-    val processed = CompletableDeferred<Unit>()
-    val collector =
-      launch(start = CoroutineStart.UNDISPATCHED) {
-        zoomState.pendingScroll.collect { (scroll, maxValue) ->
-          scrollState.scroll(scroll, maxValue)
-          processed.complete(Unit)
-        }
-      }
-
-    // Begin a scroll and keep it in progress.
-    val scrollJob =
-      launch(start = CoroutineStart.UNDISPATCHED) {
-        scrollState.scrollableState.scroll { suspendCancellableCoroutine<Unit> {} }
-      }
-    assertTrue(scrollState.scrollableState.isScrollInProgress)
-
-    // A zoom emits scroll compensation while the scroll is in progress. The compensation is stale,
-    // so it must be dropped rather than applied, leaving maxValue untouched.
-    zoomState.zoom(factor = 2f, centroidX = 50f) { scrollState.value }
-    processed.await()
-
-    assertEquals(maxValueBefore, scrollState.maxValue)
-
-    scrollJob.cancelAndJoin()
-    collector.cancelAndJoin()
-  }
-
   private fun createScrollState(
     xSnapStep: Double? = null,
     initialScroll: Scroll.Absolute = Scroll.Absolute.Start,
@@ -300,22 +262,6 @@ class VicoScrollStateTest {
           layerDimensions = layerDimensions,
         )
         it.maxValue = 100f
-      }
-
-  private fun createZoomState(): VicoZoomState =
-    VicoZoomState(
-        zoomEnabled = true,
-        initialZoom = Zoom.fixed(1f),
-        minZoom = Zoom.fixed(1f),
-        maxZoom = Zoom.fixed(4f),
-      )
-      .also {
-        it.update(
-          context = context,
-          layerDimensions = MutableCartesianLayerDimensions(xSpacing = 10f),
-          bounds = Rect(0f, 0f, 100f, 100f),
-          scroll = 0f,
-        )
       }
 
   private class SuspendingFrameClock : MonotonicFrameClock {

--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoZoomStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoZoomStateTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.cancelAndJoin
@@ -44,10 +45,24 @@ class VicoZoomStateTest {
   @MockK private lateinit var context: CartesianMeasuringContext
   @MockK private lateinit var ranges: CartesianChartRanges
 
+  // As in CartesianChartHostImpl, one MutableCartesianLayerDimensions instance is shared: the zoom
+  // state scales it, and the scroll state then derives its maximum from it. The content is much
+  // wider than the bounds so that the scroll compensation isn’t clamped.
+  private val layerDimensions = MutableCartesianLayerDimensions(xSpacing = 100f)
+  private var bounds = Rect(0f, 0f, 100f, 100f)
+  private var layoutDirection = LayoutDirection.Ltr
+
   @BeforeTest
   fun setUp() {
     MockKAnnotations.init(this, relaxed = true)
-    every { context.layoutDirection } returns LayoutDirection.Ltr
+    bounds = Rect(0f, 0f, 100f, 100f)
+    layoutDirection = LayoutDirection.Ltr
+    every { context.layoutDirection } answers { layoutDirection }
+    every { context.isLtr } answers { layoutDirection == LayoutDirection.Ltr }
+    every { context.layoutDirectionMultiplier } answers
+      {
+        if (layoutDirection == LayoutDirection.Ltr) 1 else -1
+      }
     every { context.ranges } returns ranges
     every { ranges.xLength } returns 10.0
     every { ranges.xStep } returns 1.0
@@ -67,7 +82,7 @@ class VicoZoomStateTest {
 
     val exception =
       assertFailsWith<IllegalArgumentException> {
-        sut.update(context, MutableCartesianLayerDimensions(), Rect(0f, 0f, 10f, 10f), 0f)
+        sut.update(context, MutableCartesianLayerDimensions(), Rect(0f, 0f, 10f, 10f))
       }
 
     assertTrue(exception.message!!.contains("maxZoom") && exception.message!!.contains("minZoom"))
@@ -85,7 +100,7 @@ class VicoZoomStateTest {
         maxZoom = maxZoom,
       )
 
-    sut.update(context, MutableCartesianLayerDimensions(), Rect(0f, 0f, 10f, 10f), 0f)
+    sut.update(context, MutableCartesianLayerDimensions(), Rect(0f, 0f, 10f, 10f))
 
     assertEquals(1f..1f, sut.valueRange)
   }
@@ -102,7 +117,7 @@ class VicoZoomStateTest {
         maxZoom = maxZoom,
       )
 
-    sut.update(context, MutableCartesianLayerDimensions(), Rect(0f, 0f, 10f, 10f), 0f)
+    sut.update(context, MutableCartesianLayerDimensions(), Rect(0f, 0f, 10f, 10f))
 
     assertEquals(1f..2f, sut.valueRange)
   }
@@ -112,8 +127,6 @@ class VicoZoomStateTest {
     runBlocking(SuspendingFrameClock()) {
       val frameClock = coroutineContext[MonotonicFrameClock] as SuspendingFrameClock
       val sut = createZoomState()
-      val scrollCollector =
-        launch(start = CoroutineStart.UNDISPATCHED) { sut.pendingScroll.collect {} }
 
       val ongoingJob =
         launch(start = CoroutineStart.UNDISPATCHED) {
@@ -129,11 +142,242 @@ class VicoZoomStateTest {
 
       assertTrue(ongoingJob.isCancelled)
       assertEquals(2f, sut.value)
-
-      scrollCollector.cancelAndJoin()
     }
 
-  private fun createZoomState(): VicoZoomState =
+  @Test
+  fun `When a zoom gesture occurs, then the zoom factor and the scroll value are updated together`() =
+    runBlocking {
+      val scrollState = createScrollState()
+      val sut = createZoomState(scrollState)
+      scrollState.scroll(Scroll.Absolute.pixels(50f))
+      val scrollBefore = scrollState.value
+
+      // The host applies gesture zooms undispatched, so this mirrors what a pointer event does.
+      launch(start = CoroutineStart.UNDISPATCHED) { sut.zoom(factor = 2f, centroidX = 50f) }
+
+      // Both updates have already been applied, with no suspension in between for a frame to be
+      // drawn with the new zoom factor and the old scroll value.
+      assertEquals(2f, sut.value)
+      assertNotEquals(scrollBefore, scrollState.value)
+      assertEquals(150f, scrollState.value)
+    }
+
+  @Test
+  fun `When zoom gestures occur in rapid succession, then every scroll compensation is applied`() =
+    runBlocking {
+      val scrollState = createScrollState()
+      val sut = createZoomState(scrollState)
+      scrollState.scroll(Scroll.Absolute.pixels(50f))
+
+      // Two events arriving back to back, as during a fast pinch. Neither may lose its
+      // compensation: each one’s is an absolute scroll value derived from the current one, so a
+      // dropped step permanently mis-anchors the content.
+      repeat(2) {
+        launch(start = CoroutineStart.UNDISPATCHED) { sut.zoom(factor = 1.5f, centroidX = 50f) }
+      }
+
+      assertEquals(2.25f, sut.value)
+      assertEquals(175f, scrollState.value)
+    }
+
+  @Test
+  fun `When zoom gestures occur in rapid succession, then the maximum scroll value tracks the total zoom`() =
+    runBlocking {
+      val scrollState = createScrollState()
+      val sut = createZoomState(scrollState)
+      // Near the end of the content, where an understated maximum clamps the compensation.
+      scrollState.scroll(Scroll.Absolute.pixels(800f))
+
+      // Two steps between draws, so `layerDimensions` stays scaled to the zoom factor of the last
+      // one. The second step's maximum must describe the total zoom (2.25x), not the step ratio
+      // (1.5x) applied to the last-drawn dimensions.
+      repeat(2) {
+        launch(start = CoroutineStart.UNDISPATCHED) { sut.zoom(factor = 1.5f, centroidX = 50f) }
+      }
+
+      assertEquals(2.25f, sut.value)
+      // Content is 10 * 100 * 2.25 = 2250 wide against 100 of viewport.
+      assertEquals(2150f, scrollState.maxValue)
+      // Unclamped, so the anchor is preserved. A maximum computed from the step ratio would be
+      // 1400, clamping this to 1400 and mis-anchoring the content by 462.5px.
+      assertEquals(1862.5f, scrollState.value)
+    }
+
+  @Test
+  fun `When a scroll is in progress, then a zoom gesture's scroll compensation is still applied`() =
+    runBlocking {
+      val scrollState = createScrollState()
+      val sut = createZoomState(scrollState)
+      scrollState.scroll(Scroll.Absolute.pixels(50f))
+
+      // A fling left over from a previous pan. During a pinch the zoom detector consumes the
+      // pointer events, so no drag starts to stop it; the compensation must not be gated on it.
+      val scrollJob =
+        launch(start = CoroutineStart.UNDISPATCHED) {
+          scrollState.scrollableState.scroll { suspendCancellableCoroutine<Unit> {} }
+        }
+      assertTrue(scrollState.scrollableState.isScrollInProgress)
+
+      sut.zoom(factor = 2f, centroidX = 50f)
+
+      assertEquals(2f, sut.value)
+      assertEquals(150f, scrollState.value)
+
+      scrollJob.cancelAndJoin()
+    }
+
+  @Test
+  fun `When zooming in RTL, then the content under the anchor stays in place`() = runBlocking {
+    layoutDirection = LayoutDirection.Rtl
+    val scrollState = createScrollState()
+    val sut = createZoomState(scrollState)
+    // In RTL the scroll value is negative, running from 0 at the content's start edge.
+    assertEquals(-900f, scrollState.maxValue)
+
+    // The anchor is the bounds' left edge, which in RTL is 100px into the content from the start
+    // edge. Doubling the zoom moves that content point to 200px, so the viewport's start edge has
+    // to move to 100px into the content, i.e. a scroll value of -100.
+    sut.zoom(factor = 2f, centroidX = bounds.left)
+
+    assertEquals(2f, sut.value)
+    assertEquals(-100f, scrollState.value)
+  }
+
+  @Test
+  fun `When zooming in RTL at the start edge, then the scroll value is unchanged`() = runBlocking {
+    layoutDirection = LayoutDirection.Rtl
+    val scrollState = createScrollState()
+    val sut = createZoomState(scrollState)
+
+    // The bounds' right edge is the start edge in RTL, so the anchor sits on the content's start
+    // edge and there is nothing to compensate—mirroring a zoom at `bounds.left` in LTR.
+    sut.zoom(factor = 2f, centroidX = bounds.right)
+
+    assertEquals(2f, sut.value)
+    assertEquals(0f, scrollState.value)
+  }
+
+  @Test
+  fun `When zooming in RTL mid-content, then the anchor is preserved`() = runBlocking {
+    layoutDirection = LayoutDirection.Rtl
+    val scrollState = createScrollState()
+    val sut = createZoomState(scrollState)
+    scrollState.scroll(Scroll.Absolute.pixels(-300f))
+
+    // Start edge 300px into the content, anchor a further 50px in (bounds are 100 wide), so the
+    // anchored content point is at 350px and moves to 700px. Keeping it 50px from the start edge
+    // puts that edge at 650px.
+    sut.zoom(factor = 2f, centroidX = 50f)
+
+    assertEquals(2f, sut.value)
+    assertEquals(-650f, scrollState.value)
+  }
+
+  @Test
+  fun `When a zoom changes nothing, then initialZoom keeps being applied`() = runBlocking {
+    var initialZoomValue = 1f
+    val scrollState = createScrollState()
+    val sut =
+      VicoZoomState(
+        zoomEnabled = true,
+        initialZoom = Zoom { _, _, _ -> initialZoomValue },
+        minZoom = Zoom.fixed(1f),
+        maxZoom = Zoom.fixed(4f),
+      )
+    sut.setScrollState(scrollState)
+    sut.update(context, MutableCartesianLayerDimensions(xSpacing = 100f), bounds)
+    assertEquals(1f, sut.value)
+
+    // Already at minZoom, so this is clamped back and nothing moves on screen. It must therefore
+    // not mark the state overridden, which would permanently suppress initialZoom.
+    sut.zoom(factor = 0.5f, centroidX = 50f)
+    assertEquals(1f, sut.value)
+
+    initialZoomValue = 2f
+    sut.update(context, MutableCartesianLayerDimensions(xSpacing = 100f), bounds)
+
+    assertEquals(2f, sut.value)
+  }
+
+  @Test
+  fun `When a zoom does change the factor, then initialZoom stops being applied`() = runBlocking {
+    var initialZoomValue = 1f
+    val scrollState = createScrollState()
+    val sut =
+      VicoZoomState(
+        zoomEnabled = true,
+        initialZoom = Zoom { _, _, _ -> initialZoomValue },
+        minZoom = Zoom.fixed(1f),
+        maxZoom = Zoom.fixed(4f),
+      )
+    sut.setScrollState(scrollState)
+    sut.update(context, MutableCartesianLayerDimensions(xSpacing = 100f), bounds)
+
+    sut.zoom(factor = 2f, centroidX = 50f)
+    assertEquals(2f, sut.value)
+
+    initialZoomValue = 3f
+    sut.update(context, MutableCartesianLayerDimensions(xSpacing = 100f), bounds)
+
+    assertEquals(2f, sut.value)
+  }
+
+  @Test
+  fun `When the layer bounds are inset, then zoom and animateZoom anchor identically`() =
+    runBlocking {
+      // A 400px canvas with a 60px start axis, so the layer bounds' center (230) differs from the
+      // canvas' (200).
+      bounds = Rect(60f, 0f, 400f, 100f)
+
+      val zoomScrollState = createScrollState()
+      val zoomed = createZoomState(zoomScrollState)
+      zoomed.zoom(Zoom.fixed(2f))
+
+      val animatedScrollState = createScrollState()
+      val animated = createZoomState(animatedScrollState)
+      animated.animateZoom(Zoom.fixed(2f), tween(durationMillis = 0))
+
+      assertEquals(2f, zoomed.value)
+      assertEquals(2f, animated.value)
+      // Anchored on the layer bounds' center: 230 - 60 = 170px into the content, doubling to 340,
+      // so the start edge moves to 170. Anchoring on the canvas' center would give 140.
+      assertEquals(170f, zoomScrollState.value)
+      assertEquals(animatedScrollState.value, zoomScrollState.value)
+    }
+
+  @Test
+  fun `When the scroll state is detached, then a zoom does not write to it`() = runBlocking {
+    val scrollState = createScrollState()
+    val sut = createZoomState(scrollState)
+    scrollState.scroll(Scroll.Absolute.pixels(50f))
+    val scrollBefore = scrollState.value
+    val maxValueBefore = scrollState.maxValue
+
+    // As the host does when it leaves composition.
+    scrollState.clearUpdated()
+    sut.zoom(factor = 2f, centroidX = 50f)
+
+    assertEquals(2f, sut.value)
+    assertEquals(scrollBefore, scrollState.value)
+    assertEquals(maxValueBefore, scrollState.maxValue)
+  }
+
+  @Test
+  fun `When the scroll state is replaced, then a zoom compensates the new one`() = runBlocking {
+    val replaced = createScrollState()
+    val sut = createZoomState(replaced)
+    replaced.scroll(Scroll.Absolute.pixels(50f))
+    val current = createScrollState()
+    current.scroll(Scroll.Absolute.pixels(50f))
+
+    sut.setScrollState(current)
+    sut.zoom(factor = 2f, centroidX = 50f)
+
+    assertEquals(150f, current.value)
+    assertEquals(50f, replaced.value)
+  }
+
+  private fun createZoomState(scrollState: VicoScrollState = createScrollState()): VicoZoomState =
     VicoZoomState(
         zoomEnabled = true,
         initialZoom = Zoom.fixed(1f),
@@ -141,12 +385,22 @@ class VicoZoomStateTest {
         maxZoom = Zoom.fixed(4f),
       )
       .also {
-        it.update(
-          context = context,
-          layerDimensions = MutableCartesianLayerDimensions(xSpacing = 10f),
-          bounds = Rect(0f, 0f, 100f, 100f),
-          scroll = 0f,
-        )
+        it.setScrollState(scrollState)
+        it.update(context = context, layerDimensions = layerDimensions, bounds = bounds)
+      }
+
+  private fun createScrollState(): VicoScrollState =
+    VicoScrollState(
+        scrollEnabled = true,
+        initialScroll = Scroll.Absolute.Start,
+        autoScroll = Scroll.Absolute.Start,
+        autoScrollCondition = AutoScrollCondition.Never,
+        autoScrollAnimationSpec = tween(),
+        xSnapStep = null,
+        snapAnimationSpec = tween(),
+      )
+      .also {
+        it.update(context = context, bounds = bounds, layerDimensions = layerDimensions)
       }
 
   private class SuspendingFrameClock : MonotonicFrameClock {

--- a/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoZoomStateTest.kt
+++ b/vico/compose/src/androidHostTest/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoZoomStateTest.kt
@@ -45,9 +45,7 @@ class VicoZoomStateTest {
   @MockK private lateinit var context: CartesianMeasuringContext
   @MockK private lateinit var ranges: CartesianChartRanges
 
-  // As in CartesianChartHostImpl, one MutableCartesianLayerDimensions instance is shared: the zoom
-  // state scales it, and the scroll state then derives its maximum from it. The content is much
-  // wider than the bounds so that the scroll compensation isn’t clamped.
+  // Share dimensions as the host does, with enough content to avoid clamping most anchors.
   private val layerDimensions = MutableCartesianLayerDimensions(xSpacing = 100f)
   private var bounds = Rect(0f, 0f, 100f, 100f)
   private var layoutDirection = LayoutDirection.Ltr
@@ -155,8 +153,7 @@ class VicoZoomStateTest {
       // The host applies gesture zooms undispatched, so this mirrors what a pointer event does.
       launch(start = CoroutineStart.UNDISPATCHED) { sut.zoom(factor = 2f, centroidX = 50f) }
 
-      // Both updates have already been applied, with no suspension in between for a frame to be
-      // drawn with the new zoom factor and the old scroll value.
+      // Both values must update before the launch returns.
       assertEquals(2f, sut.value)
       assertNotEquals(scrollBefore, scrollState.value)
       assertEquals(150f, scrollState.value)
@@ -169,9 +166,6 @@ class VicoZoomStateTest {
       val sut = createZoomState(scrollState)
       scrollState.scroll(Scroll.Absolute.pixels(50f))
 
-      // Two events arriving back to back, as during a fast pinch. Neither may lose its
-      // compensation: each one’s is an absolute scroll value derived from the current one, so a
-      // dropped step permanently mis-anchors the content.
       repeat(2) {
         launch(start = CoroutineStart.UNDISPATCHED) { sut.zoom(factor = 1.5f, centroidX = 50f) }
       }
@@ -188,9 +182,7 @@ class VicoZoomStateTest {
       // Near the end of the content, where an understated maximum clamps the compensation.
       scrollState.scroll(Scroll.Absolute.pixels(800f))
 
-      // Two steps between draws, so `layerDimensions` stays scaled to the zoom factor of the last
-      // one. The second step's maximum must describe the total zoom (2.25x), not the step ratio
-      // (1.5x) applied to the last-drawn dimensions.
+      // No draw between events: the dimensions still reflect the initial zoom.
       repeat(2) {
         launch(start = CoroutineStart.UNDISPATCHED) { sut.zoom(factor = 1.5f, centroidX = 50f) }
       }
@@ -198,8 +190,7 @@ class VicoZoomStateTest {
       assertEquals(2.25f, sut.value)
       // Content is 10 * 100 * 2.25 = 2250 wide against 100 of viewport.
       assertEquals(2150f, scrollState.maxValue)
-      // Unclamped, so the anchor is preserved. A maximum computed from the step ratio would be
-      // 1400, clamping this to 1400 and mis-anchoring the content by 462.5px.
+      // Anchor: (800 + 50) * 2.25 - 50 = 1862.5.
       assertEquals(1862.5f, scrollState.value)
     }
 
@@ -210,8 +201,7 @@ class VicoZoomStateTest {
       val sut = createZoomState(scrollState)
       scrollState.scroll(Scroll.Absolute.pixels(50f))
 
-      // A fling left over from a previous pan. During a pinch the zoom detector consumes the
-      // pointer events, so no drag starts to stop it; the compensation must not be gated on it.
+      // Keep a scroll active throughout the zoom, as a leftover fling would be.
       val scrollJob =
         launch(start = CoroutineStart.UNDISPATCHED) {
           scrollState.scrollableState.scroll { suspendCancellableCoroutine<Unit> {} }
@@ -234,9 +224,7 @@ class VicoZoomStateTest {
     // In RTL the scroll value is negative, running from 0 at the content's start edge.
     assertEquals(-900f, scrollState.maxValue)
 
-    // The anchor is the bounds' left edge, which in RTL is 100px into the content from the start
-    // edge. Doubling the zoom moves that content point to 200px, so the viewport's start edge has
-    // to move to 100px into the content, i.e. a scroll value of -100.
+    // The anchor is 100px from the RTL start edge; doubling zoom requires -100px of scroll.
     sut.zoom(factor = 2f, centroidX = bounds.left)
 
     assertEquals(2f, sut.value)
@@ -249,8 +237,6 @@ class VicoZoomStateTest {
     val scrollState = createScrollState()
     val sut = createZoomState(scrollState)
 
-    // The bounds' right edge is the start edge in RTL, so the anchor sits on the content's start
-    // edge and there is nothing to compensate—mirroring a zoom at `bounds.left` in LTR.
     sut.zoom(factor = 2f, centroidX = bounds.right)
 
     assertEquals(2f, sut.value)
@@ -264,9 +250,7 @@ class VicoZoomStateTest {
     val sut = createZoomState(scrollState)
     scrollState.scroll(Scroll.Absolute.pixels(-300f))
 
-    // Start edge 300px into the content, anchor a further 50px in (bounds are 100 wide), so the
-    // anchored content point is at 350px and moves to 700px. Keeping it 50px from the start edge
-    // puts that edge at 650px.
+    // Anchor: (300 + 50) * 2 - 50 = 650px from the RTL start edge.
     sut.zoom(factor = 2f, centroidX = 50f)
 
     assertEquals(2f, sut.value)
@@ -288,8 +272,6 @@ class VicoZoomStateTest {
     sut.update(context, MutableCartesianLayerDimensions(xSpacing = 100f), bounds)
     assertEquals(1f, sut.value)
 
-    // Already at minZoom, so this is clamped back and nothing moves on screen. It must therefore
-    // not mark the state overridden, which would permanently suppress initialZoom.
     sut.zoom(factor = 0.5f, centroidX = 50f)
     assertEquals(1f, sut.value)
 
@@ -325,8 +307,7 @@ class VicoZoomStateTest {
   @Test
   fun `When the layer bounds are inset, then zoom and animateZoom anchor identically`() =
     runBlocking {
-      // A 400px canvas with a 60px start axis, so the layer bounds' center (230) differs from the
-      // canvas' (200).
+      // The layer center is 230px; the canvas center is 200px.
       bounds = Rect(60f, 0f, 400f, 100f)
 
       val zoomScrollState = createScrollState()
@@ -339,8 +320,7 @@ class VicoZoomStateTest {
 
       assertEquals(2f, zoomed.value)
       assertEquals(2f, animated.value)
-      // Anchored on the layer bounds' center: 230 - 60 = 170px into the content, doubling to 340,
-      // so the start edge moves to 170. Anchoring on the canvas' center would give 140.
+      // Layer-relative anchor: 230 - 60 = 170px; canvas-relative anchoring would give 140px.
       assertEquals(170f, zoomScrollState.value)
       assertEquals(animatedScrollState.value, zoomScrollState.value)
     }
@@ -353,7 +333,6 @@ class VicoZoomStateTest {
     val scrollBefore = scrollState.value
     val maxValueBefore = scrollState.maxValue
 
-    // As the host does when it leaves composition.
     scrollState.clearUpdated()
     sut.zoom(factor = 2f, centroidX = 50f)
 

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -296,9 +296,7 @@ internal fun CartesianChartHostImpl(
 
   LaunchedEffect(model) { onViewportChange() }
 
-  // The zoom factor is observed rather than reported by the zoom handler: a zoom changes the
-  // viewport whether or not it moves the scroll value, and `zoom(Zoom)` and `animateZoom` change it
-  // without going through any handler at all.
+  // Observe programmatic zooms and zooms that leave the scroll value unchanged, too.
   LaunchedEffect(scrollState, zoomState) {
     merge(
         scrollState.consumedXDeltas,
@@ -312,8 +310,7 @@ internal fun CartesianChartHostImpl(
 
   DisposableEffect(zoomState) { onDispose { zoomState.clearUpdated() } }
 
-  // Keyed on both, so that replacing either is picked up here rather than at the next draw, which
-  // may never come.
+  // Bind outside the draw pass, which is skipped when the chart has no area.
   DisposableEffect(zoomState, scrollState) {
     zoomState.setScrollState(scrollState)
     onDispose { zoomState.setScrollState(null) }
@@ -328,17 +325,11 @@ internal fun CartesianChartHostImpl(
             consumeMoveEvents = chart.markerController.consumeMoveEvents,
             onInteraction = onInteraction,
             onZoom =
-              // `scrollState` is a key even though this lambda no longer reads it. The
-              // `pointerInput` this is passed to is keyed on `onZoom`, and its gesture loop closes
-              // over `scrollState`, so without this key a replaced scroll state would leave that
-              // loop bound to the old one.
+              // Changing onZoom restarts the pointer-input loop with the current scroll state.
               remember(zoomState, scrollState, coroutineScope) {
                 if (zoomState.zoomEnabled) {
                   { factor, centroid ->
-                    // `UNDISPATCHED` so that the zoom factor and its scroll compensation are
-                    // applied within this pointer event, before the next frame is drawn. `zoom`
-                    // reaches them without suspending unless a programmatic zoom is in progress,
-                    // which it cancels.
+                    // Apply gesture zooms within the pointer event, before the next draw.
                     coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
                       zoomState.zoom(factor, centroid.x)
                     }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/CartesianChartHost.kt
@@ -296,18 +296,28 @@ internal fun CartesianChartHostImpl(
 
   LaunchedEffect(model) { onViewportChange() }
 
-  LaunchedEffect(scrollState.consumedXDeltas, scrollState.unconsumedXDeltas) {
-    merge(scrollState.consumedXDeltas, scrollState.unconsumedXDeltas).collect { onViewportChange() }
-  }
-
-  LaunchedEffect(zoomState, scrollState) {
-    zoomState.pendingScroll.collect { (scroll, maxValue) ->
-      scrollState.scroll(scroll, maxValue)
-      onViewportChange()
-    }
+  // The zoom factor is observed rather than reported by the zoom handler: a zoom changes the
+  // viewport whether or not it moves the scroll value, and `zoom(Zoom)` and `animateZoom` change it
+  // without going through any handler at all.
+  LaunchedEffect(scrollState, zoomState) {
+    merge(
+        scrollState.consumedXDeltas,
+        scrollState.unconsumedXDeltas,
+        snapshotFlow { zoomState.value },
+      )
+      .collect { onViewportChange() }
   }
 
   DisposableEffect(scrollState) { onDispose { scrollState.clearUpdated() } }
+
+  DisposableEffect(zoomState) { onDispose { zoomState.clearUpdated() } }
+
+  // Keyed on both, so that replacing either is picked up here rather than at the next draw, which
+  // may never come.
+  DisposableEffect(zoomState, scrollState) {
+    zoomState.setScrollState(scrollState)
+    onDispose { zoomState.setScrollState(null) }
+  }
 
   ChartHostBox(modifier, chartAreaHeight, measureExtras) {
     Canvas(
@@ -318,11 +328,19 @@ internal fun CartesianChartHostImpl(
             consumeMoveEvents = chart.markerController.consumeMoveEvents,
             onInteraction = onInteraction,
             onZoom =
+              // `scrollState` is a key even though this lambda no longer reads it. The
+              // `pointerInput` this is passed to is keyed on `onZoom`, and its gesture loop closes
+              // over `scrollState`, so without this key a replaced scroll state would leave that
+              // loop bound to the old one.
               remember(zoomState, scrollState, coroutineScope) {
                 if (zoomState.zoomEnabled) {
                   { factor, centroid ->
-                    coroutineScope.launch {
-                      zoomState.zoom(factor, centroid.x) { scrollState.value }
+                    // `UNDISPATCHED` so that the zoom factor and its scroll compensation are
+                    // applied within this pointer event, before the next frame is drawn. `zoom`
+                    // reaches them without suspending unless a programmatic zoom is in progress,
+                    // which it cancels.
+                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                      zoomState.zoom(factor, centroid.x)
                     }
                   }
                 } else {
@@ -341,12 +359,7 @@ internal fun CartesianChartHostImpl(
 
       if (chart.layerBounds.isEmpty) return@Canvas
 
-      zoomState.update(
-        measuringContext.value,
-        layerDimensions,
-        chart.layerBounds,
-        scrollState.value,
-      )
+      zoomState.update(measuringContext.value, layerDimensions, chart.layerBounds)
       scrollState.update(measuringContext.value, chart.layerBounds, layerDimensions)
 
       if (model != lastHandledModel) {

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -228,33 +228,15 @@ public class VicoScrollState {
   }
 
   /**
-   * Applies a zoom’s scroll compensation, which keeps the content under the zoom anchor in place.
+   * Applies zoom anchoring synchronously with the zoom factor. Bypasses [scrollableState] so an
+   * ongoing scroll cannot delay or discard the compensation.
    *
-   * [VicoZoomState] calls this synchronously, in the same dispatch in which it updates the zoom
-   * factor, so that no frame renders a new zoom factor with an uncompensated scroll value.
-   *
-   * The compensation deliberately bypasses [scrollableState]: it isn’t a scroll gesture but a
-   * correction to one that has already been decided, so it must neither wait for an in-progress
-   * scroll nor be dropped because of one. During a pinch, the zoom detector consumes the pointer
-   * events, so no drag starts to stop a fling left over from a previous pan; gating the
-   * compensation on [ScrollableState.isScrollInProgress] would therefore mis-anchor the whole
-   * gesture. Writing [value] directly is also what makes the update atomic with the zoom factor, as
-   * going through [scrollableState] would require suspending.
-   *
-   * A fling that scrolls by deltas—the default fling behavior—carries on correctly against the
-   * corrected value. One that animates toward a target captured before the zoom does not:
-   * [SnapFlingBehavior] and [performSnap] derive their deltas from the pre-zoom
-   * [CartesianLayerDimensions.xSpacing], and the desktop and web decay flings replay absolute
-   * scroll values, so a zoom landing mid-fling leaves the scroll off-target until the next gesture.
-   * Anchoring correctly through such a fling would require invalidating it, which this doesn’t do.
+   * This does not invalidate in-flight animations: snap flings and desktop/web decay flings may
+   * still settle off-target after a zoom.
    */
   internal fun applyZoomScroll(value: Float, maxValue: Float) {
-    // No-op while detached from a host, as the removed `scroll(Scroll, Float)` also was: `update`
-    // supplies these and `clearUpdated` nulls them on disposal, and both this instance's measured
-    // maximum and whatever reads the result belong to a host that is no longer drawing it.
     withUpdated { _, _, _ ->
-      // Set `maxValue` first: its setter re-clamps `value` to the new maximum, and the incoming
-      // value is already expressed in terms of that maximum.
+      // Update the clamping range before applying the compensated value.
       this.maxValue = maxValue
       this.value = value
     }

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoScrollState.kt
@@ -227,18 +227,36 @@ public class VicoScrollState {
     }
   }
 
-  internal suspend fun scroll(scroll: Scroll, maxScroll: Float) {
-    // This receives the scroll compensation for a zoom gesture—an absolute target computed
-    // from the scroll value and the content width at the time of the zoom event. It’s valid
-    // only while the user isn’t scrolling: if a pan or fling is already in progress (e.g., the
-    // pinch turned into a pan without the scroll ever becoming idle for a frame), then by the
-    // time the scroll stops, the target and `maxScroll` are stale, and applying them would
-    // roll the viewport back to the position at the time of the zoom. Drop the stale
-    // compensation; the zoom handler emits a fresh one on every zoom event.
-    if (scrollableState.isScrollInProgress) return
-    maxValue = maxScroll
-    withUpdated { context, layerDimensions, bounds ->
-      scrollableState.scrollBy(scroll.getDelta(context, layerDimensions, bounds, maxValue, value))
+  /**
+   * Applies a zoom’s scroll compensation, which keeps the content under the zoom anchor in place.
+   *
+   * [VicoZoomState] calls this synchronously, in the same dispatch in which it updates the zoom
+   * factor, so that no frame renders a new zoom factor with an uncompensated scroll value.
+   *
+   * The compensation deliberately bypasses [scrollableState]: it isn’t a scroll gesture but a
+   * correction to one that has already been decided, so it must neither wait for an in-progress
+   * scroll nor be dropped because of one. During a pinch, the zoom detector consumes the pointer
+   * events, so no drag starts to stop a fling left over from a previous pan; gating the
+   * compensation on [ScrollableState.isScrollInProgress] would therefore mis-anchor the whole
+   * gesture. Writing [value] directly is also what makes the update atomic with the zoom factor, as
+   * going through [scrollableState] would require suspending.
+   *
+   * A fling that scrolls by deltas—the default fling behavior—carries on correctly against the
+   * corrected value. One that animates toward a target captured before the zoom does not:
+   * [SnapFlingBehavior] and [performSnap] derive their deltas from the pre-zoom
+   * [CartesianLayerDimensions.xSpacing], and the desktop and web decay flings replay absolute
+   * scroll values, so a zoom landing mid-fling leaves the scroll off-target until the next gesture.
+   * Anchoring correctly through such a fling would require invalidating it, which this doesn’t do.
+   */
+  internal fun applyZoomScroll(value: Float, maxValue: Float) {
+    // No-op while detached from a host, as the removed `scroll(Scroll, Float)` also was: `update`
+    // supplies these and `clearUpdated` nulls them on disposal, and both this instance's measured
+    // maximum and whatever reads the result belong to a host that is no longer drawing it.
+    withUpdated { _, _, _ ->
+      // Set `maxValue` first: its setter re-clamps `value` to the new maximum, and the incoming
+      // value is already expressed in terms of that maximum.
+      this.maxValue = maxValue
+      this.value = value
     }
   }
 

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoZoomState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoZoomState.kt
@@ -49,11 +49,7 @@ public class VicoZoomState {
   private var layerDimensions: MutableCartesianLayerDimensions? = null
   private var bounds: Rect? = null
   private var scrollState: VicoScrollState? = null
-  /**
-   * The zoom factor by which [layerDimensions] is currently scaled. [update] rescales
-   * [layerDimensions] to match [value], but that happens once per draw, while any number of zooms
-   * can occur in between, so [value] alone doesn’t describe [layerDimensions]’ current scale.
-   */
+  // The dimensions’ scale can lag behind the zoom value between draws.
   private var layerDimensionsZoom = 0f
   private val zoomMutatorMutex = MutatorMutex()
 
@@ -162,11 +158,6 @@ public class VicoZoomState {
     }
   }
 
-  /**
-   * Returns the _x_ coordinate of the zoom anchor at [bias], which runs from 0 at the [bounds]’
-   * start edge to 1 at their end edge. [bounds] are the [CartesianChart]’s layer bounds, which are
-   * inset from the canvas by the axes, so the canvas’s coordinates can’t stand in for theirs.
-   */
   private fun getCentroidX(context: CartesianMeasuringContext, bounds: Rect, bias: Float): Float =
     bounds.getStart(context.isLtr) + context.layoutDirectionMultiplier * bias * bounds.width
 
@@ -190,14 +181,6 @@ public class VicoZoomState {
     }
   }
 
-  /**
-   * Sets the [VicoScrollState] whose scroll value anchors zooms, or `null` when there is none.
-   *
-   * This is deliberately separate from [update], which runs in the draw pass: a host can replace
-   * its [VicoScrollState] without a draw following—it returns early before [update] when the chart
-   * has no area—and a zoom in that window would otherwise anchor against, and write to, the state
-   * that was discarded.
-   */
   internal fun setScrollState(scrollState: VicoScrollState?) {
     this.scrollState = scrollState
   }
@@ -235,46 +218,25 @@ public class VicoZoomState {
   }
 
   /**
-   * Updates [value] and, to keep the content under the zoom anchor in place, the scroll value.
-   *
-   * This is deliberately non-suspending, and it applies both updates itself rather than handing the
-   * scroll compensation off to a collector. A zoom factor is only meaningful together with the
-   * scroll value that anchors it, so the two must be applied in the same dispatch: if the scroll
-   * compensation were applied later, a frame could render the new zoom factor with the old scroll
-   * value, scaling the content around the wrong anchor and correcting it a frame later—a visible
-   * sideways jump, most noticeable on the last, largest step of a fast pinch. Suspending here would
-   * also mean the compensation could be canceled after [value] had already been updated (by
-   * [zoomMutatorMutex], when the next zoom event arrives mid-gesture), permanently mis-anchoring
-   * the content: each step's compensation is an absolute scroll value derived from the current one,
-   * so a step that never lands isn't recovered by the steps that follow.
+   * Updates zoom and its scroll compensation without suspension so neither can be applied alone.
    */
   private fun rawZoom(factor: Float, centroidX: Float) {
     withUpdated { context, layerDimensions, bounds ->
       val oldValue = value
       value *= factor
-      // Only now, once the zoom has actually moved. `overridden` permanently stops `update` from
-      // re-applying `initialZoom`, and the `Saver` persists it, so a zoom that changes nothing—a
-      // pinch that's already clamped at `minZoom` or `maxZoom`—must not set it.
+      // A clamped no-op must not disable future initial zoom updates.
       if (value == oldValue) return@withUpdated
       overridden = true
       if (layerDimensionsZoom == 0f) return@withUpdated
       val scrollState = this.scrollState ?: return@withUpdated
       val scroll = scrollState.value
-      // Scale `layerDimensions` from the zoom factor they’re currently scaled by, not from
-      // `oldValue`. The two diverge as soon as a second zoom occurs before the next draw, and
-      // scaling by the step ratio would then describe `layerDimensionsZoom * factor` rather than
-      // `value`, understating the maximum scroll value and clamping the compensation away.
+      // Use the dimensions’ last-drawn scale, which may differ from the previous zoom value.
       val maxScrollDistance =
         context.getMaxScrollDistance(
           bounds.width,
           layerDimensions.copyScaled(value / layerDimensionsZoom),
         )
-      // The anchor’s distance from the content’s start edge, in scalable content pixels. Scroll
-      // values are signed by the layout direction—`layoutDirectionMultiplier * scroll` is the
-      // distance from the content’s start edge to the bounds’ start edge—and the anchor’s offset
-      // from that edge runs the same way, so the two are converted together. Unlike the dimensions
-      // above, the anchor scales by the step ratio, converting `scroll` from `oldValue`’s pixels to
-      // `value`’s.
+      // Convert the anchor to scalable pixels from the content’s start edge, accounting for RTL.
       val transformationAxisX =
         context.layoutDirectionMultiplier * (scroll + centroidX - bounds.getStart(context.isLtr)) -
           layerDimensions.unscalableStartPadding

--- a/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoZoomState.kt
+++ b/vico/compose/src/commonMain/kotlin/com/patrykandpatrick/vico/compose/cartesian/VicoZoomState.kt
@@ -34,8 +34,7 @@ import com.patrykandpatrick.vico.compose.cartesian.layer.MutableCartesianLayerDi
 import com.patrykandpatrick.vico.compose.cartesian.layer.copyScaled
 import com.patrykandpatrick.vico.compose.cartesian.layer.scale
 import com.patrykandpatrick.vico.compose.common.Defaults
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import com.patrykandpatrick.vico.compose.common.getStart
 
 /** Houses information on a [CartesianChart]’s zoom factor. Allows for zoom customization. */
 public class VicoZoomState {
@@ -49,9 +48,13 @@ public class VicoZoomState {
   private var context: CartesianMeasuringContext? = null
   private var layerDimensions: MutableCartesianLayerDimensions? = null
   private var bounds: Rect? = null
-  private var scroll = 0f
-  private val _pendingScroll = MutableSharedFlow<Pair<Scroll, Float>>()
-  internal val pendingScroll = _pendingScroll.asSharedFlow()
+  private var scrollState: VicoScrollState? = null
+  /**
+   * The zoom factor by which [layerDimensions] is currently scaled. [update] rescales
+   * [layerDimensions] to match [value], but that happens once per draw, while any number of zooms
+   * can occur in between, so [value] alone doesn’t describe [layerDimensions]’ current scale.
+   */
+  private var layerDimensionsZoom = 0f
   private val zoomMutatorMutex = MutatorMutex()
 
   /** The current zoom factor. */
@@ -112,11 +115,9 @@ public class VicoZoomState {
   public suspend fun zoom(zoom: Zoom) {
     zoomMutatorMutex.mutate {
       withUpdated { context, layerDimensions, bounds ->
-        val unscaled = if (value != 0f) layerDimensions.copyScaled(1f / value) else layerDimensions
+        val unscaled = unscale(layerDimensions)
         val newValue = zoom.getValue(context, unscaled, bounds)
-        if (newValue != value) {
-          rawZoom(newValue / value, context.canvasWidth / 2f) { scroll }
-        }
+        if (newValue != value) rawZoom(newValue / value, getCentroidX(context, bounds, bias = 0.5f))
       }
     }
   }
@@ -134,14 +135,14 @@ public class VicoZoomState {
   ) {
     zoomMutatorMutex.mutate {
       withUpdated { context, layerDimensions, bounds ->
-        val unscaled = if (value != 0f) layerDimensions.copyScaled(1f / value) else layerDimensions
+        val unscaled = unscale(layerDimensions)
         val target = zoom.getValue(context, unscaled, bounds).coerceIn(valueRange)
         if (target == value) return@withUpdated
-        val centroidX = bounds.left + bias * bounds.width
+        val centroidX = getCentroidX(context, bounds, bias)
         val anim = TargetBasedAnimation(animationSpec, Float.VectorConverter, value, target)
         val durationNanos = anim.durationNanos
         if (durationNanos == 0L) {
-          rawZoom(target / value, centroidX) { scroll }
+          rawZoom(target / value, centroidX)
           return@withUpdated
         }
         var startNanos = -1L
@@ -153,13 +154,30 @@ public class VicoZoomState {
           }
           val current = anim.getValueFromNanos(playTime).coerceIn(valueRange)
           val factor = if (value != 0f) current / value else 1f
-          rawZoom(factor, centroidX) { scroll }
+          rawZoom(factor, centroidX)
         }
         val finalFactor = if (value != 0f) target / value else 1f
-        rawZoom(finalFactor, centroidX) { scroll }
+        rawZoom(finalFactor, centroidX)
       }
     }
   }
+
+  /**
+   * Returns the _x_ coordinate of the zoom anchor at [bias], which runs from 0 at the [bounds]’
+   * start edge to 1 at their end edge. [bounds] are the [CartesianChart]’s layer bounds, which are
+   * inset from the canvas by the axes, so the canvas’s coordinates can’t stand in for theirs.
+   */
+  private fun getCentroidX(context: CartesianMeasuringContext, bounds: Rect, bias: Float): Float =
+    bounds.getStart(context.isLtr) + context.layoutDirectionMultiplier * bias * bounds.width
+
+  private fun unscale(
+    layerDimensions: MutableCartesianLayerDimensions
+  ): MutableCartesianLayerDimensions =
+    if (layerDimensionsZoom != 0f) {
+      layerDimensions.copyScaled(1f / layerDimensionsZoom)
+    } else {
+      layerDimensions
+    }
 
   private inline fun withUpdated(
     block: (CartesianMeasuringContext, MutableCartesianLayerDimensions, Rect) -> Unit
@@ -172,16 +190,26 @@ public class VicoZoomState {
     }
   }
 
+  /**
+   * Sets the [VicoScrollState] whose scroll value anchors zooms, or `null` when there is none.
+   *
+   * This is deliberately separate from [update], which runs in the draw pass: a host can replace
+   * its [VicoScrollState] without a draw following—it returns early before [update] when the chart
+   * has no area—and a zoom in that window would otherwise anchor against, and write to, the state
+   * that was discarded.
+   */
+  internal fun setScrollState(scrollState: VicoScrollState?) {
+    this.scrollState = scrollState
+  }
+
   internal fun update(
     context: CartesianMeasuringContext,
     layerDimensions: MutableCartesianLayerDimensions,
     bounds: Rect,
-    scroll: Float,
   ) {
     this.context = context
     this.layerDimensions = layerDimensions
     this.bounds = bounds
-    this.scroll = scroll
 
     val minValue = minZoom.getValue(context, layerDimensions, bounds)
     val maxValue = maxZoom.getValue(context, layerDimensions, bounds)
@@ -192,27 +220,70 @@ public class VicoZoomState {
     valueRange = minValue..maxValue
     if (!overridden) value = initialZoom.getValue(context, layerDimensions, bounds)
     layerDimensions.scale(value)
+    layerDimensionsZoom = value
   }
 
-  internal suspend fun zoom(factor: Float, centroidX: Float, scroll: () -> Float) {
-    zoomMutatorMutex.mutate { rawZoom(factor, centroidX, scroll) }
+  internal fun clearUpdated() {
+    context = null
+    layerDimensions = null
+    bounds = null
+    layerDimensionsZoom = 0f
   }
 
-  private suspend fun rawZoom(factor: Float, centroidX: Float, scroll: () -> Float) {
+  internal suspend fun zoom(factor: Float, centroidX: Float) {
+    zoomMutatorMutex.mutate { rawZoom(factor, centroidX) }
+  }
+
+  /**
+   * Updates [value] and, to keep the content under the zoom anchor in place, the scroll value.
+   *
+   * This is deliberately non-suspending, and it applies both updates itself rather than handing the
+   * scroll compensation off to a collector. A zoom factor is only meaningful together with the
+   * scroll value that anchors it, so the two must be applied in the same dispatch: if the scroll
+   * compensation were applied later, a frame could render the new zoom factor with the old scroll
+   * value, scaling the content around the wrong anchor and correcting it a frame later—a visible
+   * sideways jump, most noticeable on the last, largest step of a fast pinch. Suspending here would
+   * also mean the compensation could be canceled after [value] had already been updated (by
+   * [zoomMutatorMutex], when the next zoom event arrives mid-gesture), permanently mis-anchoring
+   * the content: each step's compensation is an absolute scroll value derived from the current one,
+   * so a step that never lands isn't recovered by the steps that follow.
+   */
+  private fun rawZoom(factor: Float, centroidX: Float) {
     withUpdated { context, layerDimensions, bounds ->
-      overridden = true
       val oldValue = value
       value *= factor
+      // Only now, once the zoom has actually moved. `overridden` permanently stops `update` from
+      // re-applying `initialZoom`, and the `Saver` persists it, so a zoom that changes nothing—a
+      // pinch that's already clamped at `minZoom` or `maxZoom`—must not set it.
       if (value == oldValue) return@withUpdated
-      val scroll = scroll()
+      overridden = true
+      if (layerDimensionsZoom == 0f) return@withUpdated
+      val scrollState = this.scrollState ?: return@withUpdated
+      val scroll = scrollState.value
+      // Scale `layerDimensions` from the zoom factor they’re currently scaled by, not from
+      // `oldValue`. The two diverge as soon as a second zoom occurs before the next draw, and
+      // scaling by the step ratio would then describe `layerDimensionsZoom * factor` rather than
+      // `value`, understating the maximum scroll value and clamping the compensation away.
       val maxScrollDistance =
-        context.getMaxScrollDistance(bounds.width, layerDimensions.copyScaled(value / oldValue))
+        context.getMaxScrollDistance(
+          bounds.width,
+          layerDimensions.copyScaled(value / layerDimensionsZoom),
+        )
+      // The anchor’s distance from the content’s start edge, in scalable content pixels. Scroll
+      // values are signed by the layout direction—`layoutDirectionMultiplier * scroll` is the
+      // distance from the content’s start edge to the bounds’ start edge—and the anchor’s offset
+      // from that edge runs the same way, so the two are converted together. Unlike the dimensions
+      // above, the anchor scales by the step ratio, converting `scroll` from `oldValue`’s pixels to
+      // `value`’s.
       val transformationAxisX =
-        scroll + centroidX - bounds.left - layerDimensions.unscalableStartPadding
+        context.layoutDirectionMultiplier * (scroll + centroidX - bounds.getStart(context.isLtr)) -
+          layerDimensions.unscalableStartPadding
       val zoomedTransformationAxisX = transformationAxisX * (value / oldValue)
-      _pendingScroll.emit(
-        Scroll.Absolute.pixels(scroll + zoomedTransformationAxisX - transformationAxisX) to
-          maxScrollDistance
+      scrollState.applyZoomScroll(
+        value =
+          scroll +
+            context.layoutDirectionMultiplier * (zoomedTransformationAxisX - transformationAxisX),
+        maxValue = maxScrollDistance,
       )
     }
   }


### PR DESCRIPTION
Fixes #1601.

## The bug

During a pinch, `VicoZoomState` applied the zoom factor and then handed the anchoring scroll compensation to `CartesianChartHost` through a rendezvous `MutableSharedFlow`. Three things went wrong with that:

1. **The two writes landed in different dispatches**, so a frame could render a new zoom factor against a stale scroll value — the reporter measured this on every replay of a recorded pinch.
2. **The emission suspended while `zoomMutatorMutex` was held**, so the next pinch event cancelled it. The zoom factor survives (it is written before the suspension) but its compensation is lost, and because each compensation is an *absolute* scroll value derived from the current one, a dropped step is never recovered by the steps that follow. This is the dominant term: in a host-side reproduction, two rapid steps totalling 2.25× landed at scroll 100 where settled steps landed at 175 — a permanent 75px mis-anchoring.
3. **`scroll(Scroll, Float)` dropped whatever survived** while a scroll was in progress. During a pinch it usually is: `detectZoomGestures` consumes the pointer events once past slop, so no drag ever starts to stop a fling left over from a previous pan.

## The fix

`rawZoom` is non-suspending and writes both values itself through a new `VicoScrollState.applyZoomScroll`; the host applies gesture zooms with `CoroutineStart.UNDISPATCHED`. Neither write can be separated from the other or cancelled in between, and the compensation is no longer gated on `isScrollInProgress` — it isn't a scroll gesture but a correction to one already decided.

## Also fixed

These surfaced while reworking the above and share the lines involved, so they are in the same commit rather than split artificially:

| | |
|---|---|
| **Stale max scroll value** | The maximum was derived by scaling `layerDimensions` by the *step* ratio, but they are rescaled only by `update` in the draw pass — so any step after the first within one frame computed the maximum for the wrong factor and clamped the compensation away, producing the very jump this PR targets. `layerDimensionsZoom` now records the factor they are actually scaled by. |
| **RTL anchoring** | The anchor arithmetic assumed the content's start edge is on the left, so it had the wrong magnitude *and* sign in RTL. It now converts through `layoutDirectionMultiplier` against `bounds.getStart(isLtr)`, and `animateZoom`'s `bias` runs from the start edge as its KDoc says. Both reduce to the previous expressions in LTR. |
| **`overridden` set too eagerly** | It was set before checking whether the zoom moved anything, and `Saver` persists it — so a pinch already clamped at `minZoom` permanently stopped `initialZoom` from being reapplied, surviving process death. |
| **`zoom(Zoom)` anchor** | It anchored on the canvas' midpoint while the compensation is expressed relative to the layer bounds, which are inset by the axes, so it disagreed with `animateZoom` by the axis width (30px on a 400px chart with a 60px axis) and scrolled the wrong way when the start axis exceeded half the canvas. Both now share `getCentroidX`. |
| **Detached scroll state** | The zoom state's reference was assigned from the draw pass, which is skipped when the chart has no area, so a replaced `VicoScrollState` could go unnoticed. It is now tracked by a `DisposableEffect` keyed on both states, and `applyZoomScroll` no-ops while detached, as the method it replaced did. |

## Testing

`VicoZoomStateTest` goes from 4 cases to 16. Each new test was verified to fail against the code it guards — the expected/actual pairs are the numbers quoted above (`2150` vs `1400` for the max scroll value, `-100` vs `0` and `-650` vs `-550` for RTL, `170` vs `140` for the anchor, `2.0` vs `1.0` for `overridden`, `50` vs `150` for the detached state).

`./gradlew compileDebugSources test` passes, and the `desktop`, `iosSimulatorArm64`, `js` and `wasmJs` targets compile.

Public API is unchanged: every added or changed member (`applyZoomScroll`, `setScrollState`, `clearUpdated`, `update`, `zoom(Float, Float)`) is `internal`, as were the two removed ones.

## Known limitation

Documented on `applyZoomScroll` rather than silently left: a fling animating toward a target captured *before* the zoom is not invalidated by the compensation, so `SnapFlingBehavior`, `performSnap` and the desktop and web decay flings can still settle off-target when a zoom lands mid-fling. Fixing that needs the compensation to invalidate in-flight animations — a generation counter, or folding scroll and zoom into a single arbitrated viewport operation — which is a larger change than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
